### PR TITLE
Rename module from netcdftime to cftime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 
 # Test source distribution.
 install:
-  - python setup.py sdist && version=$(python setup.py --version) && pushd dist  && pip install netcdftime-${version}.tar.gz && popd
+  - python setup.py sdist && version=$(python setup.py --version) && pushd dist  && pip install cftime-${version}.tar.gz && popd
 
 script:
   - if [[ $BUILD_DOCS == "true" ]]; then

--- a/COPYING
+++ b/COPYING
@@ -15,7 +15,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 
-parts of pyiso8601 are included in netcdftime under the following license:
+parts of pyiso8601 are included in cftime under the following license:
 
 Copyright (c) 2007 Michael Twomey
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include *.txt
 include README.md
 include COPYING
-recursive-include netcdftime *.py
-recursive-include netcdftime *.pyx
+recursive-include cftime *.py
+recursive-include cftime *.pyx

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# netcdftime
+# cftime
 Time-handling functionality from netcdf4-python
 
-[![Linux Build Status](https://travis-ci.org/Unidata/netcdftime.svg?branch=master)](https://travis-ci.org/Unidata/netcdftime)
-[![Windows Build Status](https://ci.appveyor.com/api/projects/status/fl9taa9je4e6wi7n/branch/master?svg=true)](https://ci.appveyor.com/project/jswhit/netcdftime/branch/master)
-[![PyPI package](https://badge.fury.io/py/netcdftime.svg)](http://python.org/pypi/netcdftime)
+[![Linux Build Status](https://travis-ci.org/Unidata/cftime.svg?branch=master)](https://travis-ci.org/Unidata/cftime)
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/fl9taa9je4e6wi7n/branch/master?svg=true)](https://ci.appveyor.com/project/jswhit/cftime/branch/master)
+[![PyPI package](https://badge.fury.io/py/cftime.svg)](http://python.org/pypi/cftime)
 
 ## News
-11/8/2016: `netcdftime` was split out of the [netcdf4-python](https://github.com/Unidata/netcdf4-python) package.
+11/8/2016: `cftime` was split out of the [netcdf4-python](https://github.com/Unidata/netcdf4-python) package.
 
 ## Quick Start
-* Clone GitHub repository (`git clone https://github.com/Unidata/netcdftime.git`), or get source tarball from [PyPI](https://pypi.python.org/pypi/netcdftime). Links to Windows and OS X precompiled binary packages are also available on [PyPI](https://pypi.python.org/pypi/netcdftime).
+* Clone GitHub repository (`git clone https://github.com/Unidata/cftime.git`), or get source tarball from [PyPI](https://pypi.python.org/pypi/cftime). Links to Windows and OS X precompiled binary packages are also available on [PyPI](https://pypi.python.org/pypi/cftime).
 
 * Make sure [numpy](http://www.numpy.org/) and [Cython](http://cython.org/) are
   installed and you have [Python](https://www.python.org) 2.7 or newer.
@@ -19,4 +19,4 @@ Time-handling functionality from netcdf4-python
 * To run all the tests, execute `py.test`.
 
 ## Documentation
-See the online [docs](http://unidata.github.io/netcdftime) for more details.
+See the online [docs](http://unidata.github.io/cftime) for more details.

--- a/cftime/__init__.py
+++ b/cftime/__init__.py
@@ -1,0 +1,9 @@
+from ._cftime import utime, JulianDayFromDate, DateFromJulianDay
+from ._cftime import _parse_date, date2index, time2index
+from ._cftime import datetime
+from ._cftime import DatetimeNoLeap, DatetimeAllLeap, Datetime360Day, DatetimeJulian, \
+                         DatetimeGregorian, DatetimeProlepticGregorian
+from ._cftime import microsec_units, millisec_units, \
+                         sec_units, hr_units, day_units, min_units
+from ._cftime import num2date, date2num, date2index
+from ._cftime import __version__

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -50,7 +50,7 @@ gregorian = real_datetime(1582,10,15)
 def _dateparse(timestr):
     """parse a string of the form time-units since yyyy-mm-dd hh:mm:ss,
     return a datetime instance"""
-    # same as version in netcdftime, but returns a timezone naive
+    # same as version in cftime, but returns a timezone naive
     # python datetime instance with the utc_offset included.
     timestr_split = timestr.split()
     units = timestr_split[0].lower()
@@ -173,7 +173,7 @@ def date2num(dates,units,calendar='standard'):
                 return times[0]
             else:
                 return numpy.reshape(numpy.array(times), shape)
-        else: # use netcdftime module for other calendars
+        else: # use cftime module for other calendars
             cdftime = utime(units,calendar=calendar)
             return cdftime.date2num(dates)
 
@@ -277,7 +277,7 @@ def num2date(times,units,calendar='standard'):
             return dates[0]
         else:
             return numpy.reshape(numpy.array(dates), shape)
-    else: # use netcdftime for other calendars
+    else: # use cftime for other calendars
         cdftime = utime(units,calendar=calendar)
         return cdftime.num2date(times)
 
@@ -334,7 +334,7 @@ def date2index(dates, nctime, calendar=None, select='exact'):
         # use python datetime
         times = date2num(dates,nctime.units,calendar=calendar)
         return time2index(times, nctime, calendar, select)
-    else: # use netcdftime module for other cases
+    else: # use cftime module for other cases
         return _date2index(dates, nctime, calendar, select)
 
 
@@ -550,7 +550,7 @@ def DateFromJulianDay(JD, calendar='standard'):
     the Gregorian calendar (i.e. calendar='proleptic_gregorian', or
     calendar = 'standard'/'gregorian' and the date is after 1582-10-15).
     Otherwise, it's a 'phony' datetime object which is actually an instance
-    of netcdftime.datetime.
+    of cftime.datetime.
 
 
     Algorithm:
@@ -669,7 +669,7 @@ def DateFromJulianDay(JD, calendar='standard'):
     if calendar in 'proleptic_gregorian':
         # datetime.datetime does not support years < 1
         #if year < 0:
-        if (year < 0).any(): # netcdftime issue #28
+        if (year < 0).any(): # cftime issue #28
             datetime_type = DatetimeProlepticGregorian
         else:
             datetime_type = real_datetime
@@ -902,7 +902,7 @@ The datetime instances returned by C{num2date} are 'real' python datetime
 objects if the date falls in the Gregorian calendar (i.e.
 C{calendar='proleptic_gregorian', 'standard'} or C{'gregorian'} and
 the date is after 1582-10-15). Otherwise, they are 'phony' datetime
-objects which are actually instances of C{L{netcdftime.datetime}}.  This is
+objects which are actually instances of C{L{cftime.datetime}}.  This is
 because the python datetime module cannot handle the weird dates in some
 calendars (such as C{'360_day'} and C{'all_leap'}) which don't exist in any real
 world calendar.
@@ -910,7 +910,7 @@ world calendar.
 
 Example usage:
 
->>> from netcdftime import utime
+>>> from cftime import utime
 >>> from datetime import  datetime
 >>> cdftime = utime('hours since 0001-01-01 00:00:00')
 >>> date = datetime.now()
@@ -1118,7 +1118,7 @@ units to datetime objects.
         objects if the date falls in the Gregorian calendar (i.e.
         C{calendar='proleptic_gregorian'}, or C{calendar = 'standard'/'gregorian'} and
         the date is after 1582-10-15). Otherwise, they are 'phony' datetime
-        objects which are actually instances of netcdftime.datetime.  This is
+        objects which are actually instances of cftime.datetime.  This is
         because the python datetime module cannot handle the weird dates in some
         calendars (such as C{'360_day'} and C{'all_leap'}) which
         do not exist in any real world calendar.
@@ -1484,7 +1484,7 @@ Gregorial calendar.
 
     # Python's datetime.datetime uses the proleptic Gregorian
     # calendar. This boolean is used to decide whether a
-    # netcdftime.datetime instance can be converted to
+    # cftime.datetime instance can be converted to
     # datetime.datetime.
     cdef readonly bint datetime_compatible
 
@@ -1732,7 +1732,7 @@ Has strftime, timetuple, replace, __repr__, and __str__ methods. The
 format of the string produced by __str__ is controlled by self.format
 (default %Y-%m-%d %H:%M:%S). Supports comparisons with other phony
 datetime instances using the same calendar; comparison with
-datetime.datetime instances is possible for netcdftime.datetime
+datetime.datetime instances is possible for cftime.datetime
 instances using 'gregorian' and 'proleptic_gregorian' calendars.
 
 Instance variables are year,month,day,hour,minute,second,microsecond,dayofwk,dayofyr,
@@ -1876,7 +1876,7 @@ cdef void assert_valid_date(datetime dt, bint (*is_leap)(int),
     if dt.microsecond < 0 or dt.microsecond > 999999:
         raise ValueError("invalid microsecond provided in {0!r}".format(dt))
 
-# Add a datetime.timedelta to a netcdftime.datetime instance. Uses
+# Add a datetime.timedelta to a cftime.datetime instance. Uses
 # integer arithmetic to avoid rounding errors and preserve
 # microsecond accuracy.
 #
@@ -1964,7 +1964,7 @@ cdef tuple add_timedelta(datetime dt, delta, bint (*is_leap)(int), bint julian_g
 
     return (year, month, day, hour, minute, second, microsecond, -1, 1)
 
-# Add a datetime.timedelta to a netcdftime.datetime instance with the 360_day calendar.
+# Add a datetime.timedelta to a cftime.datetime instance with the 360_day calendar.
 #
 # Assumes that the 360_day calendar (unlike the rest of supported
 # calendars) has the year 0. Also, there are no leap years and all

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "dev" %}
 
 package:
-  name: netcdftime
+  name: cftime
   version: {{ version }}
 
 source:
@@ -28,11 +28,11 @@ test:
   requires:
     - pytest
   imports:
-    - netcdftime
+    - cftime
   commands:
     - py.test -vv test
 
 about:
-  home: https://github.com/Unidata/netcdftime
+  home: https://github.com/Unidata/cftime
   license: OSI Approved
   summary: 'Provides an object-oriented python interface to the netCDF version 4 library..'

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = netcdftime
+SPHINXPROJ    = cftime
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'netcdftime'
+project = 'cftime'
 copyright = '2018, Jeff Whitaker'
 author = 'Jeff Whitaker'
 
@@ -103,7 +103,7 @@ html_static_path = ['_static']
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'netcdftimedoc'
+htmlhelp_basename = 'cftimedoc'
 
 
 # -- Options for LaTeX output ------------------------------------------------
@@ -130,7 +130,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'netcdftime.tex', 'netcdftime Documentation',
+    (master_doc, 'cftime.tex', 'cftime Documentation',
      'Jeff Whitaker', 'manual'),
 ]
 
@@ -140,7 +140,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'netcdftime', 'netcdftime Documentation',
+    (master_doc, 'cftime', 'cftime Documentation',
      [author], 1)
 ]
 
@@ -151,8 +151,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'netcdftime', 'netcdftime Documentation',
-     author, 'netcdftime', 'One line description of project.',
+    (master_doc, 'cftime', 'cftime Documentation',
+     author, 'cftime', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-netcdftime
-==========
+cftime
+======
 
 Python library for decoding time units and variable values in a netCDF file
 conforming to the Climate and Forecasting (CF) netCDF conventions.
@@ -8,8 +8,8 @@ conforming to the Climate and Forecasting (CF) netCDF conventions.
    :maxdepth: 2
    :caption: Contents:
 
-.. automodule:: netcdftime
-   :members: date2num, date2index, num2date, JulianDayFromDate
+.. automodule:: cftime
+   :members: datetime, date2num, date2index, num2date, JulianDayFromDate, DatetimeJulian, DatetimeProlepticGregorian, DatetimeNoLeap, DatetimeAllLeap, DatetimeGregorian
 
 
 Indices and tables

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -9,7 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=.
 set BUILDDIR=_build
-set SPHINXPROJ=netcdftime
+set SPHINXPROJ=cftime
 
 if "%1" == "" goto help
 

--- a/netcdftime/__init__.py
+++ b/netcdftime/__init__.py
@@ -1,9 +1,0 @@
-from ._netcdftime import utime, JulianDayFromDate, DateFromJulianDay
-from ._netcdftime import _parse_date, date2index, time2index
-from ._netcdftime import datetime
-from ._netcdftime import DatetimeNoLeap, DatetimeAllLeap, Datetime360Day, DatetimeJulian, \
-                         DatetimeGregorian, DatetimeProlepticGregorian
-from ._netcdftime import microsec_units, millisec_units, \
-                         sec_units, hr_units, day_units, min_units
-from ._netcdftime import num2date, date2num, date2index
-from ._netcdftime import __version__

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from setuptools import setup, Extension
 
 rootpath = os.path.abspath(os.path.dirname(__file__))
 
-def extract_version(module='netcdftime'):
+def extract_version(module='cftime'):
     version = None
-    fname = os.path.join(rootpath, module, '_netcdftime.pyx')
+    fname = os.path.join(rootpath, module, '_cftime.pyx')
     with open(fname) as f:
         for line in f:
             if (line.startswith('__version__')):
@@ -23,13 +23,13 @@ with open('requirements-dev.txt') as f:
 tests_require = [req.strip() for req in reqs]
 
 setup(
-    name='netcdftime',
+    name='cftime',
     author='Jeff Whitaker',
     author_email='jeffrey.s.whitaker@noaa.gov',
     description='Time-handling functionality from netcdf4-python',
-    packages=['netcdftime'],
+    packages=['cftime'],
     version=extract_version(),
-    ext_modules=[Extension('netcdftime._netcdftime',sources=['netcdftime/_netcdftime.pyx'])],
+    ext_modules=[Extension('cftime._cftime',sources=['cftime/_cftime.pyx'])],
     setup_requires=install_requires,
     install_requires=install_requires,
     tests_require=tests_require)

--- a/test/test_netcdftime.py
+++ b/test/test_netcdftime.py
@@ -7,21 +7,21 @@ from datetime import datetime, timedelta
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
-from netcdftime import datetime as datetimex
-from netcdftime import (utime, JulianDayFromDate, DateFromJulianDay,
+from cftime import datetime as datetimex
+from cftime import (utime, JulianDayFromDate, DateFromJulianDay,
                         DatetimeNoLeap, DatetimeAllLeap, Datetime360Day,
                         DatetimeJulian, DatetimeGregorian,
                         DatetimeProlepticGregorian)
-from netcdftime import num2date, date2num, date2index, _parse_date
+from cftime import num2date, date2num, date2index, _parse_date
 
 
-# test netcdftime module for netCDF time <--> python datetime conversions.
+# test cftime module for netCDF time <--> python datetime conversions.
 
 
 dtime = namedtuple('dtime', ('values', 'units', 'calendar'))
 
 
-class NetCDFTimeVariable(object):
+class CFTimeVariable(object):
     '''dummy "netCDF" variable to hold time info'''
     def __init__(self, values, calendar='standard', units=None):
 
@@ -53,7 +53,7 @@ class NetCDFTimeVariable(object):
         return self.values.shape
 
 
-class netcdftimeTestCase(unittest.TestCase):
+class cftimeTestCase(unittest.TestCase):
 
     def setUp(self):
         self.cdftime_mixed = utime('hours since 0001-01-01 00:00:00')
@@ -78,7 +78,7 @@ class netcdftimeTestCase(unittest.TestCase):
             'days since 1600-02-28 00:00:00', calendar='NOLEAP')
 
     def runTest(self):
-        """testing netcdftime"""
+        """testing cftime"""
         # test mixed julian/gregorian calendar
         # check attributes.
         self.assertTrue(self.cdftime_mixed.units == 'hours')
@@ -205,7 +205,7 @@ class netcdftimeTestCase(unittest.TestCase):
         assert_almost_equal(
             self.cdftime_360day.date2num(self.cdftime_360day.origin), 0.0)
         # check date2num,num2date methods.
-        # use datetime from netcdftime, since this date doesn't
+        # use datetime from cftime, since this date doesn't
         # exist in "normal" calendars.
         d = datetimex(2000, 2, 30)
         t1 = self.cdftime_360day.date2num(d)
@@ -432,7 +432,7 @@ class netcdftimeTestCase(unittest.TestCase):
         assert (num == -7)
         assert (num2date(num, units) == date)
         units = 'hours since 1482-10-15 -07:00 UTC'
-        # date before gregorian switch, netcdftime datetime used
+        # date before gregorian switch, cftime datetime used
         date = datetime(1482,10,15)
         num = date2num(date,units)
         date2 = num2date(num, units)
@@ -609,13 +609,13 @@ class TestDate2index(unittest.TestCase):
                                           'hours since 1900-01-01', 'standard')
 
         self.time_vars = {}
-        self.time_vars['time'] = NetCDFTimeVariable(
+        self.time_vars['time'] = CFTimeVariable(
             values=self.standardtime,
             units='hours since 1900-01-01')
 
         self.first_timestamp = datetime(2000, 1, 1)
         units = 'days since 1901-01-01'
-        self.time_vars['time2'] = NetCDFTimeVariable(
+        self.time_vars['time2'] = CFTimeVariable(
             values=date2num([self.first_timestamp], units),
             units=units)
 
@@ -627,7 +627,7 @@ class TestDate2index(unittest.TestCase):
         for ndate in range(ntimes-1):
             date += (ndate+1)*timedelta(hours=1)
             dates.append(date)
-        self.time_vars['time3'] = NetCDFTimeVariable(
+        self.time_vars['time3'] = CFTimeVariable(
             values=date2num(dates, units),
             units=units)
 
@@ -871,17 +871,17 @@ class DateTime(unittest.TestCase):
             """
             return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
 
-        # sutracting two netcdftime.datetime instances
+        # sutracting two cftime.datetime instances
         delta = self.date2_365_day - self.date1_365_day
         # date1 and date2 are exactly one day apart
         self.assertEqual(total_seconds(delta), 86400)
 
-        # subtracting netcdftime.datetime from datetime.datetime
+        # subtracting cftime.datetime from datetime.datetime
         delta = self.datetime_date1 - self.date3_gregorian
         # real_date2 and real_date1 are exactly one day apart
         self.assertEqual(total_seconds(delta), 86400)
 
-        # subtracting datetime.datetime from netcdftime.datetime
+        # subtracting datetime.datetime from cftime.datetime
         delta = self.date3_gregorian - self.datetime_date1
         # real_date2 and real_date1 are exactly one day apart
         self.assertEqual(total_seconds(delta), -86400)
@@ -996,7 +996,7 @@ class DateTime(unittest.TestCase):
             self.date2_365_day > self.datetime_date1
 
         def not_comparable_3():
-            "compare datetime.datetime to netcdftime.datetime with a non-gregorian calendar"
+            "compare datetime.datetime to cftime.datetime with a non-gregorian calendar"
             self.datetime_date1 > self.date2_365_day
 
         def not_comparable_4():


### PR DESCRIPTION
I replaced every occurence of 'netcdftime' with 'cftime'. This will break tests until github/travis/appveyor names are updated. Resolves #36 .