### PR TITLE
Add only_use_cftime_datetimes flag to num2date

### DIFF
--- a/netcdftime/_netcdftime.pyx
+++ b/netcdftime/_netcdftime.pyx
@@ -178,7 +178,7 @@ def date2num(dates,units,calendar='standard'):
             return cdftime.date2num(dates)
 
 
-def num2date(times,units,calendar='standard'):
+def num2date(times,units,calendar='standard',only_use_netcdftime_datetimes=False):
     """num2date(times,units,calendar='standard')
 
     Return datetime objects given numeric time values. The units
@@ -200,6 +200,10 @@ def num2date(times,units,calendar='standard'):
     Valid calendars `'standard', 'gregorian', 'proleptic_gregorian'
     'noleap', '365_day', '360_day', 'julian', 'all_leap', '366_day'`.
     Default is `'standard'`, which is a mixed Julian/Gregorian calendar.
+
+    **`only_use_netcdftime_datetimes`**: if False (default), datetime.datetime
+    objects are returned from num2date where possible; if True dates which
+    subclass netcdftime.datetime are returned for all calendars.
 
     returns a datetime instance, or an array of datetime instances with
     approximately millisecond accuracy.
@@ -227,7 +231,11 @@ def num2date(times,units,calendar='standard'):
             raise ValueError(msg)
 
     postimes =  (numpy.asarray(times) > 0).all() # netcdf4-python issue #659
-    if postimes and ((calendar == 'proleptic_gregorian' and basedate.year >= MINYEAR) or \
+    if only_use_netcdftime_datetimes:
+        cdftime = utime(units, calendar=calendar,
+                        only_use_netcdftime_datetimes=only_use_netcdftime_datetimes)
+        return cdftime.num2date(times)
+    elif postimes and ((calendar == 'proleptic_gregorian' and basedate.year >= MINYEAR) or \
        (calendar in ['gregorian','standard'] and basedate > gregorian)):
         # use python datetime module,
         isscalar = False
@@ -533,7 +541,7 @@ Returns the fractional Julian Day (approximately millisecond accuracy).
     return jd
 
 
-def DateFromJulianDay(JD, calendar='standard'):
+def DateFromJulianDay(JD, calendar='standard', only_use_netcdftime_datetimes=False):
     """
 
     returns a 'datetime-like' object given Julian Day. Julian Day is a
@@ -546,11 +554,12 @@ def DateFromJulianDay(JD, calendar='standard'):
 
     if calendar='julian', Julian Day follows julian calendar.
 
-    The datetime object is a 'real' datetime object if the date falls in
-    the Gregorian calendar (i.e. calendar='proleptic_gregorian', or
-    calendar = 'standard'/'gregorian' and the date is after 1582-10-15).
-    Otherwise, it's a 'phony' datetime object which is actually an instance
-    of netcdftime.datetime.
+    If only_use_netcdftime_datetimes is set to True, then netcdftime.datetime
+    objects are returned for all calendars.  Otherwise the datetime object is a
+    'real' datetime object if the date falls in the Gregorian calendar
+    (i.e. calendar='proleptic_gregorian', or  calendar = 'standard'/'gregorian'
+    and the date is after 1582-10-15).  In all other cases a 'phony' datetime
+    objects are used, which are actually instances of netcdftime.datetime.
 
 
     Algorithm:
@@ -669,15 +678,21 @@ def DateFromJulianDay(JD, calendar='standard'):
     if calendar in 'proleptic_gregorian':
         # datetime.datetime does not support years < 1
         #if year < 0:
-        if (year < 0).any(): # netcdftime issue #28
-            datetime_type = DatetimeProlepticGregorian
+        if only_use_netcdftime_datetimes:
+           if calendar == 'gregorian':
+              datetime_type = DatetimeGregorian
+           else:
+              datetime_type = DatetimeProlepticGregorian
         else:
-            datetime_type = real_datetime
+            if (year < 0).any(): # netcdftime issue #28
+               datetime_type = DatetimeProlepticGregorian
+            else:
+               datetime_type = real_datetime
     elif calendar in ('standard', 'gregorian'):
         # return a 'real' datetime instance if calendar is proleptic
         # Gregorian or Gregorian and all dates are after the
         # Julian/Gregorian transition
-        if len(ind_before) == 0:
+        if len(ind_before) == 0 and not only_use_netcdftime_datetimes:
             datetime_type = real_datetime
         else:
             datetime_type = DatetimeGregorian
@@ -947,7 +962,8 @@ it should be noted that udunits treats 0 AD as identical to 1 AD."
 @ivar units:  the units part of C{unit_string} (i.e. 'days', 'hours', 'seconds').
     """
 
-    def __init__(self, unit_string, calendar='standard'):
+    def __init__(self, unit_string, calendar='standard',
+                 only_use_netcdftime_datetimes=False):
         """
 @param unit_string: a string of the form
 C{'time-units since <time-origin>'} defining the time units.
@@ -978,6 +994,10 @@ are:
  -C{'julian'}:
  Proleptic Julian calendar, extended to dates after 1582-10-5. A year is a
  leap year if it is divisible by 4.
+
+@keyword only_use_netcdftime_datetimes: if False (default), datetime.datetime
+objects are returned from num2date where possible; if True dates which subclass
+netcdftime.datetime are returned for all calendars.
 
 @returns: A class instance which may be used for converting times from netCDF
 units to datetime objects.
@@ -1014,6 +1034,7 @@ units to datetime objects.
             self._jd0 = _360DayFromDate(self.origin)
         else:
             self._jd0 = JulianDayFromDate(self.origin, calendar=self.calendar)
+        self.only_use_netcdftime_datetimes = only_use_netcdftime_datetimes
 
     def date2num(self, date):
         """
@@ -1157,16 +1178,19 @@ units to datetime objects.
                     date = []
                     for j, m in zip(jd.flat, mask.flat):
                         if not m:
-                            date.append(DateFromJulianDay(j, self.calendar))
+                            date.append(DateFromJulianDay(j, self.calendar,
+                                                          self.only_use_netcdftime_datetimes))
                         else:
                             date.append(None)
                 else:
-                    date = DateFromJulianDay(jd.flat, self.calendar)
+                    date = DateFromJulianDay(jd.flat, self.calendar,
+                                             self.only_use_netcdftime_datetimes)
             else:
                 if ismasked and mask.item():
                     date = None
                 else:
-                    date = DateFromJulianDay(jd, self.calendar)
+                    date = DateFromJulianDay(jd, self.calendar,
+                                             self.only_use_netcdftime_datetimes)
         elif self.calendar in ['noleap', '365_day']:
             if not isscalar:
                 date = [_DateFromNoLeapDay(j) for j in jd.flat]

--- a/test/test_netcdftime.py
+++ b/test/test_netcdftime.py
@@ -1188,5 +1188,49 @@ def test_str_matches_datetime_str(date_type, date_args):
     assert str(date_type(*date_args)) == str(datetime(*date_args))
 
 
+_EXPECTED_DATE_TYPES = {'noleap': DatetimeNoLeap,
+                        '365_day': DatetimeNoLeap,
+                        '360_day': Datetime360Day,
+                        'julian': DatetimeJulian,
+                        'all_leap': DatetimeAllLeap,
+                        '366_day': DatetimeAllLeap,
+                        'gregorian': DatetimeGregorian,
+                        'proleptic_gregorian': DatetimeProlepticGregorian,
+                        'standard': DatetimeGregorian}
+
+
+@pytest.mark.parametrize(
+    ['calendar', 'expected_date_type'],
+    list(_EXPECTED_DATE_TYPES.items())
+)
+def test_num2date_only_use_netcdftime_datetimes_negative_years(
+        calendar, expected_date_type):
+    result = num2date(-1000., units='days since 0001-01-01', calendar=calendar,
+                      only_use_netcdftime_datetimes=True)
+    assert isinstance(result, expected_date_type)
+
+
+@pytest.mark.parametrize(
+    ['calendar', 'expected_date_type'],
+    list(_EXPECTED_DATE_TYPES.items())
+)
+def test_num2date_only_use_netcdftime_datetimes_pre_gregorian(
+        calendar, expected_date_type):
+    result = num2date(1., units='days since 0001-01-01', calendar=calendar,
+                      only_use_netcdftime_datetimes=True)
+    assert isinstance(result, expected_date_type)
+
+
+@pytest.mark.parametrize(
+    ['calendar', 'expected_date_type'],
+    list(_EXPECTED_DATE_TYPES.items())
+)
+def test_num2date_only_use_netcdftime_datetimes_post_gregorian(
+        calendar, expected_date_type):
+    result = num2date(0., units='days since 1582-10-15', calendar=calendar,
+                      only_use_netcdftime_datetimes=True)
+    assert isinstance(result, expected_date_type)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #37 

I tried to go for the path of least resistance.  I added a flag to `DateFromJulianDay` that allows one to bypass the logic that uses `datetime.datetime` objects in certain situations (and exposed that flag in `netcdftime.num2date`).  If `only_use_netcdftime_datetimes` is `True` we have the following behavior:
- For `calendar='standard'`, `DatetimeGregorian` objects are always used
- For `calendar='gregorian'`, `DatetimeGregorian` objects are always used
- For `calendar='proleptic_gregorian'`, `DatetimeProlepticGregorian` objects are always used

If `only_use_netcdftime_datetimes` is `False` (which is the default), then the original behavior occurs.  

Does this seem like something reasonable?  I'm happy to discuss things further.