### PR TITLE
build with miniconda36 and simplify build matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,34 +1,21 @@
 environment:
+  CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
   matrix:
     - TARGET_ARCH: x64
-      CONDA_NPY: 112
+      CONDA_NPY: 111
       CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 113
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x64
       CONDA_NPY: 114
       CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 112
+      CONDA_NPY: 111
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 113
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
     - TARGET_ARCH: x64
       CONDA_NPY: 114
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 platform:
     - x64


### PR DESCRIPTION
AppVeyor is failing b/c of its old minconda.
This PRs uses the latest minconda to build all Pythons, this will make the Python 2.7 a little bit slower b/c `conda-build` have to download py2.7 but it is worth the test stability.

Note that I also reduced the build matrix to make this finish quicker.
(We don't need to build against many numpy's, only the oldest possible and the latest.)