### PR TITLE
Fix rich comparisons for datetime objects

### DIFF
--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -1616,6 +1616,13 @@ Gregorial calendar.
                 raise TypeError("cannot compare {0!r} and {1!r} (different calendars)".format(self, other))
             return PyObject_RichCompare(dt.to_tuple(), to_tuple(other), op)
         else:
+            # With Python3 we can use "return NotImplemented". If the other
+            # object does not have rich comparison instructions for cftime
+            # then a TypeError is automatically raised. With Python2 in this
+            # scenario the default behaviour is to compare the object ids
+            # which will always have a result. Therefore there is no way to
+            # differentiate between objects that do or do not have legitimate
+            # comparisons, and so we cannot remove the TypeError below.
             if sys.version_info[0] < 3:
                 raise TypeError("cannot compare {0!r} and {1!r}".format(self, other))
             else:

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -8,6 +8,7 @@ import numpy as np
 import math
 import numpy
 import re
+import sys
 import time
 from datetime import datetime as real_datetime
 from datetime import timedelta, MINYEAR
@@ -1615,7 +1616,10 @@ Gregorial calendar.
                 raise TypeError("cannot compare {0!r} and {1!r} (different calendars)".format(self, other))
             return PyObject_RichCompare(dt.to_tuple(), to_tuple(other), op)
         else:
-            return NotImplemented
+            if sys.version_info[0] < 3:
+                raise TypeError("cannot compare {0!r} and {1!r}".format(self, other))
+            else:
+                return NotImplemented
 
     cdef _getstate(self):
         return (self.year, self.month, self.day, self.hour,

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -1615,7 +1615,7 @@ Gregorial calendar.
                 raise TypeError("cannot compare {0!r} and {1!r} (different calendars)".format(self, other))
             return PyObject_RichCompare(dt.to_tuple(), to_tuple(other), op)
         else:
-            raise TypeError("cannot compare {0!r} and {1!r}".format(self, other))
+            return NotImplemented
 
     cdef _getstate(self):
         return (self.year, self.month, self.day, self.hour,


### PR DESCRIPTION
As identified in #11, rich comparisons for `cftime.datetime` objects with other unknown objects do not work as cftime raises a `TypeError` instead of returning `NotImplemented`. This pull request is to fix this.

While this works in Python 3, it should be noted that Python 2 is more problematic. The unit test `not_comparable_4` in `test_richcmp` will fail as `cftime.datetime` objects are treated as comparable with integer zero and so the `TypeError` is not raised when it is expected.