### PR TITLE
Catch and raise error for incorrectly formatted unit strings (Issue #57)

### DIFF
--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -45,19 +45,29 @@ TIMEZONE_REGEX = re.compile(
 # start of the gregorian calendar
 gregorian = real_datetime(1582,10,15)
 
+def _datesplit(timestr):
+    """split a time string into two components, units and the remainder 
+    after 'since'
+    """
+    try:
+        (units, sincestring, remainder) = timestr.split(maxsplit=2)
+    except ValueError as e:
+        raise ValueError('Incorrectly formatted CF date-time unit_string')
+
+    if sincestring.lower() != 'since':
+        raise ValueError("no 'since' in unit_string")
+
+    return units.lower(), remainder
 
 def _dateparse(timestr):
     """parse a string of the form time-units since yyyy-mm-dd hh:mm:ss,
     return a datetime instance"""
     # same as version in cftime, but returns a timezone naive
     # python datetime instance with the utc_offset included.
-    timestr_split = timestr.split()
-    units = timestr_split[0].lower()
-    if timestr_split[1].lower() != 'since':
-        raise ValueError("no 'since' in unit_string")
+
+    (units, isostring) = _datesplit(timestr)
+
     # parse the date string.
-    n = timestr.find('since')+6
-    isostring = timestr[n:]
     year, month, day, hour, minute, second, utc_offset =\
         _parse_date( isostring.strip() )
     if year >= MINYEAR:
@@ -75,17 +85,13 @@ def _dateparse(timestr):
 cdef _parse_date_and_units(timestr):
     """parse a string of the form time-units since yyyy-mm-dd hh:mm:ss
     return a tuple (units,utc_offset, datetimeinstance)"""
-    timestr_split = timestr.split()
-    units = timestr_split[0].lower()
+    (units, isostring) = _datesplit(timestr)
     if units not in _units:
         raise ValueError(
             "units must be one of 'seconds', 'minutes', 'hours' or 'days' (or singular version of these), got '%s'" % units)
-    if timestr_split[1].lower() != 'since':
-        raise ValueError("no 'since' in unit_string")
     # parse the date string.
-    n = timestr.find('since') + 6
     year, month, day, hour, minute, second, utc_offset = _parse_date(
-        timestr[n:].strip())
+        isostring.strip())
     return units, utc_offset, datetime(year, month, day, hour, minute, second)
 
 
@@ -119,7 +125,7 @@ def date2num(dates,units,calendar='standard'):
         """
         calendar = calendar.lower()
         basedate = _dateparse(units)
-        unit = units.split()[0].lower()
+        (unit, ignore) = _datesplit(units)
         # real-world calendars limited to positive reference years.
         if calendar in ['julian', 'standard', 'gregorian', 'proleptic_gregorian']:
             if basedate.year == 0:
@@ -219,7 +225,7 @@ def num2date(times,units,calendar='standard',only_use_cftime_datetimes=False):
     """
     calendar = calendar.lower()
     basedate = _dateparse(units)
-    unit = units.split()[0].lower()
+    (unit, ignore) = _datesplit(units)
     # real-world calendars limited to positive reference years.
     if calendar in ['julian', 'standard', 'gregorian', 'proleptic_gregorian']:
         if basedate.year == 0:
@@ -2046,3 +2052,4 @@ cdef tuple add_timedelta_360_day(datetime dt, delta):
     month = (month - 1) % 12 + 1
 
     return (year, month, day, hour, minute, second, microsecond, -1, 1)
+

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -50,7 +50,7 @@ def _datesplit(timestr):
     after 'since'
     """
     try:
-        (units, sincestring, remainder) = timestr.split(maxsplit=2)
+        (units, sincestring, remainder) = timestr.split(None,2)
     except ValueError as e:
         raise ValueError('Incorrectly formatted CF date-time unit_string')
 

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1049,7 +1049,7 @@ class issue57TestCase(unittest.TestCase):
         pass
 
     def test_parse_incorrect_unitstring(self):
-        for datestr in ("days since2017-05-01 ", "dayssince 2017-05-01 00:00", "days_since_2017-05-01 00:00", 
+        for datestr in ("days since2017-05-01 ", "dayssince 2017-05-01 00:00", "days snce 2017-05-01 00:00", "days_since_2017-05-01 00:00", 
             "days_since_2017-05-01_00:00"):
             self.assertRaises(
                 ValueError, cftime._cftime._dateparse, datestr)

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -12,9 +12,8 @@ from cftime import (DateFromJulianDay, Datetime360Day, DatetimeAllLeap,
                     DatetimeGregorian, DatetimeJulian, DatetimeNoLeap,
                     DatetimeProlepticGregorian, JulianDayFromDate, _parse_date,
                     date2index, date2num, num2date, utime)
-
+import cftime
 # test cftime module for netCDF time <--> python datetime conversions.
-
 
 dtime = namedtuple('dtime', ('values', 'units', 'calendar'))
 
@@ -1040,6 +1039,26 @@ class issue17TestCase(unittest.TestCase):
         for datestr in ("2017-05-01 00:00+1",):
             d = _parse_date(datestr)
             assert_equal(d, expected_parsed_date)
+
+
+class issue57TestCase(unittest.TestCase):
+    """Regression tests for issue #57."""
+    # issue 57: cftime._cftime._dateparse returns quite opaque error messages that make it difficult to 
+    # track down the source of problem
+    def setUp(self):
+        pass
+
+    def test_parse_incorrect_unitstring(self):
+        for datestr in ("days since2017-05-01 ", "dayssince 2017-05-01 00:00", "days_since_2017-05-01 00:00", 
+            "days_since_2017-05-01_00:00"):
+            self.assertRaises(
+                ValueError, cftime._cftime._dateparse, datestr)
+
+            self.assertRaises(
+                ValueError, cftime._cftime.num2date, 1, datestr)
+
+            self.assertRaises(
+                ValueError, cftime._cftime.date2num, datetime(1900, 1, 1, 0), datestr)
 
 
 _DATE_TYPES = [DatetimeNoLeap, DatetimeAllLeap, DatetimeJulian, Datetime360Day,


### PR DESCRIPTION
This addresses https://github.com/Unidata/cftime/issues/57

Previous behaviour:
```
>>> cftime._cftime._dateparse('days_since_1900-01-01')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cftime/_cftime.pyx", line 56, in cftime._cftime._dateparse
IndexError: list index out of range
```
Now
```
>>> cftime._cftime._dateparse('days_since_1900-01-01')
Traceback (most recent call last):
  File "cftime/_cftime.pyx", line 53, in cftime._cftime._datesplit
    (units, sincestring, remainder) = timestr.split(maxsplit=2)
ValueError: need more than 1 value to unpack

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cftime/_cftime.pyx", line 68, in cftime._cftime._dateparse
    (units, isostring) = _datesplit(timestr)
  File "cftime/_cftime.pyx", line 55, in cftime._cftime._datesplit
    raise ValueError('Incorrectly formatted CF date-time unit_string')
ValueError: Incorrectly formatted CF date-time unit_string
```
All instances of using `split` in the code have been changed to use `_datesplit` which checks the status of the `split` and throws the above exception. It also checks for a correct "since" string.