### PR TITLE
fix for 'day out of range error' (issue #49)

### DIFF
--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -5,8 +5,6 @@ Performs conversions of netCDF time coordinate data to/from datetime objects.
 from cpython.object cimport PyObject_RichCompare
 import cython
 import numpy as np
-import math
-import numpy
 import re
 import time
 from datetime import datetime as real_datetime
@@ -144,12 +142,12 @@ def date2num(dates,units,calendar='standard'):
             except:
                 isscalar = True
             if isscalar:
-                dates = numpy.array([dates])
+                dates = np.array([dates])
             else:
-                dates = numpy.array(dates)
+                dates = np.array(dates)
                 shape = dates.shape
             ismasked = False
-            if numpy.ma.isMA(dates) and numpy.ma.is_masked(dates):
+            if np.ma.isMA(dates) and np.ma.is_masked(dates):
                 mask = dates.mask
                 ismasked = True
             times = []
@@ -177,7 +175,7 @@ def date2num(dates,units,calendar='standard'):
             if isscalar:
                 return times[0]
             else:
-                return numpy.reshape(numpy.array(times), shape)
+                return np.reshape(np.array(times), shape)
         else: # use cftime module for other calendars
             cdftime = utime(units,calendar=calendar)
             return cdftime.date2num(dates)
@@ -235,7 +233,7 @@ def num2date(times,units,calendar='standard',only_use_cftime_datetimes=False):
             msg='negative reference year in time units, must be >= 1'
             raise ValueError(msg)
 
-    postimes =  (numpy.asarray(times) > 0).all() # netcdf4-python issue #659
+    postimes =  (np.asarray(times) > 0).all() # netcdf4-python issue #659
     if only_use_cftime_datetimes:
         cdftime = utime(units, calendar=calendar,
                         only_use_cftime_datetimes=only_use_cftime_datetimes)
@@ -249,12 +247,12 @@ def num2date(times,units,calendar='standard',only_use_cftime_datetimes=False):
         except:
             isscalar = True
         if isscalar:
-            times = numpy.array([times],dtype='d')
+            times = np.array([times],dtype='d')
         else:
-            times = numpy.array(times, dtype='d')
+            times = np.array(times, dtype='d')
             shape = times.shape
         ismasked = False
-        if numpy.ma.isMA(times) and numpy.ma.is_masked(times):
+        if np.ma.isMA(times) and np.ma.is_masked(times):
             mask = times.mask
             ismasked = True
         dates = []
@@ -281,7 +279,7 @@ def num2date(times,units,calendar='standard',only_use_cftime_datetimes=False):
                 days = tsecs // 86400.
                 msecsd = tsecs*1.e6 - days*86400.*1.e6
                 secs = msecsd // 1.e6
-                msecs = numpy.round(msecsd - secs*1.e6)
+                msecs = np.round(msecsd - secs*1.e6)
                 td = timedelta(days=days,seconds=secs,microseconds=msecs)
                 # add time delta to base date.
                 date = basedate + td
@@ -289,7 +287,7 @@ def num2date(times,units,calendar='standard',only_use_cftime_datetimes=False):
         if isscalar:
             return dates[0]
         else:
-            return numpy.reshape(numpy.array(dates), shape)
+            return np.reshape(np.array(dates), shape)
     else: # use cftime for other calendars
         cdftime = utime(units,calendar=calendar)
         return cdftime.num2date(times)
@@ -574,7 +572,7 @@ def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=False):
 
     # based on redate.py by David Finlayson.
 
-    julian = np.array(JD, dtype=float)
+    julian = np.array(JD, dtype=np.float64)
 
     if np.min(julian) < 0:
         raise ValueError('Julian Day must be positive')
@@ -582,13 +580,14 @@ def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=False):
     dayofwk = np.atleast_1d(np.int32(np.fmod(np.int32(julian + 1.5), 7)))
     # get the day (Z) and the fraction of the day (F)
     # add 0.000005 which is 452 ms in case of jd being after
-    # second 23:59:59 of a day we want to round to the next day see issue #75
-    Z = np.atleast_1d(np.int32(np.round(julian)))
+    # second 23:59:59 of a day we want to round to the next day
+    # (see netcdf4-python issue #75, also cftime issue #49)
+    Z = np.atleast_1d(np.int32(np.round(julian+0.000005)))
     F = np.atleast_1d(julian + 0.5 - Z).astype(np.float64)
     if calendar in ['standard', 'gregorian']:
         # MC
-        # alpha = int((Z - 1867216.25)/36524.25)
-        # A = Z + 1 + alpha - int(alpha/4)
+        #alpha = np.int32((Z - 1867216.25)/36524.25)
+        #A = Z + 1 + alpha - np.int32(alpha/4)
         alpha = np.int32(((Z - 1867216.) - 0.25) / 36524.25)
         A = Z + 1 + alpha - np.int32(0.25 * alpha)
         # check if dates before oct 5th 1582 are in the array
@@ -610,8 +609,8 @@ def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=False):
 
     B = A + 1524
     # MC
-    # C = int((B - 122.1)/365.25)
-    # D = int(365.25 * C)
+    #C = np.atleast_1d(np.int32((B - 122.1)/365.25))
+    #D = np.atleast_1d(np.int32(365.25 * C))
     C = np.atleast_1d(np.int32(6680. + ((B - 2439870.) - 122.1) / 365.25))
     D = np.atleast_1d(np.int32(365 * C + np.int32(0.25 * C)))
     E = np.atleast_1d(np.int32((B - D) / 30.6001))
@@ -732,8 +731,8 @@ days. Julian Day is a fractional day with approximately millisecond accuracy.
     else:
         year_offset = 0
 
-    dayofwk = int(math.fmod(int(JD + 1.5), 7))
-    (F, Z) = math.modf(JD + 0.5)
+    dayofwk = int(np.fmod(int(JD + 1.5), 7))
+    (F, Z) = np.modf(JD + 0.5)
     Z = int(Z)
     A = Z
     B = A + 1524
@@ -759,10 +758,10 @@ days. Julian Day is a fractional day with approximately millisecond accuracy.
         year = C - 4715
 
     # Convert fractions of a day to time
-    (dfrac, days) = math.modf(day / 1.0)
-    (hfrac, hours) = math.modf(dfrac * 24.0)
-    (mfrac, minutes) = math.modf(hfrac * 60.0)
-    (sfrac, seconds) = math.modf(mfrac * 60.0)
+    (dfrac, days) = np.modf(day / 1.0)
+    (hfrac, hours) = np.modf(dfrac * 24.0)
+    (mfrac, minutes) = np.modf(hfrac * 60.0)
+    (sfrac, seconds) = np.modf(mfrac * 60.0)
     microseconds = sfrac*1.e6
 
     if year_offset > 0:
@@ -770,7 +769,7 @@ days. Julian Day is a fractional day with approximately millisecond accuracy.
 
         # 365 mod 7 = 1, so the day of the week changes by one day for
         # every year in year_offset
-        dayofwk -= int(math.fmod(year_offset, 7))
+        dayofwk -= int(np.fmod(year_offset, 7))
 
         if dayofwk < 0:
             dayofwk += 7
@@ -793,8 +792,8 @@ Julian Day is a fractional day with approximately millisecond accuracy.
     if JD < 0:
         raise ValueError('Julian Day must be positive')
 
-    dayofwk = int(math.fmod(int(JD + 1.5), 7))
-    (F, Z) = math.modf(JD + 0.5)
+    dayofwk = int(np.fmod(int(JD + 1.5), 7))
+    (F, Z) = np.modf(JD + 0.5)
     Z = int(Z)
     A = Z
     B = A + 1524
@@ -822,10 +821,10 @@ Julian Day is a fractional day with approximately millisecond accuracy.
         year = C - 4715
 
     # Convert fractions of a day to time
-    (dfrac, days) = math.modf(day / 1.0)
-    (hfrac, hours) = math.modf(dfrac * 24.0)
-    (mfrac, minutes) = math.modf(hfrac * 60.0)
-    (sfrac, seconds) = math.modf(mfrac * 60.0)
+    (dfrac, days) = np.modf(day / 1.0)
+    (hfrac, hours) = np.modf(dfrac * 24.0)
+    (mfrac, minutes) = np.modf(hfrac * 60.0)
+    (sfrac, seconds) = np.modf(mfrac * 60.0)
     microseconds = sfrac*1.e6
 
     return DatetimeAllLeap(year, month, int(days), int(hours), int(minutes),
@@ -848,17 +847,17 @@ Julian Day is a fractional day with approximately millisecond accuracy.
         year_offset = 0
 
     #jd = int(360. * (year + 4716)) + int(30. * (month - 1)) + day
-    (F, Z) = math.modf(JD)
+    (F, Z) = np.modf(JD)
     year = int((Z - 0.5) / 360.) - 4716
     dayofyr = Z - (year + 4716) * 360
     month = int((dayofyr - 0.5) / 30) + 1
     day = dayofyr - (month - 1) * 30 + F
 
     # Convert fractions of a day to time
-    (dfrac, days) = math.modf(day / 1.0)
-    (hfrac, hours) = math.modf(dfrac * 24.0)
-    (mfrac, minutes) = math.modf(hfrac * 60.0)
-    (sfrac, seconds) = math.modf(mfrac * 60.0)
+    (dfrac, days) = np.modf(day / 1.0)
+    (hfrac, hours) = np.modf(dfrac * 24.0)
+    (mfrac, minutes) = np.modf(hfrac * 60.0)
+    (sfrac, seconds) = np.modf(mfrac * 60.0)
     microseconds = sfrac*1.e6
 
     return Datetime360Day(year - year_offset, month, int(days), int(hours), int(minutes),
@@ -1065,7 +1064,7 @@ units to datetime objects.
         except:
             isscalar = True
         if not isscalar:
-            date = numpy.array(date)
+            date = np.array(date)
             shape = date.shape
         if self.calendar in ['julian', 'standard', 'gregorian', 'proleptic_gregorian']:
             if isscalar:
@@ -1105,7 +1104,7 @@ units to datetime objects.
                             'there are only 30 days in every month with the 360_day calendar')
                     jdelta.append(_360DayFromDate(d) - self._jd0)
         if not isscalar:
-            jdelta = numpy.array(jdelta)
+            jdelta = np.array(jdelta)
         # convert to desired units, add time zone offset.
         if self.units in microsec_units:
             jdelta = jdelta * 86400. * 1.e6  + self.tzoffset * 60. * 1.e6
@@ -1124,7 +1123,7 @@ units to datetime objects.
         if isscalar:
             return jdelta
         else:
-            return numpy.reshape(jdelta, shape)
+            return np.reshape(jdelta, shape)
 
     def num2date(self, time_value):
         """
@@ -1154,11 +1153,11 @@ units to datetime objects.
         except:
             isscalar = True
         ismasked = False
-        if numpy.ma.isMA(time_value) and numpy.ma.is_masked(time_value):
+        if np.ma.isMA(time_value) and np.ma.is_masked(time_value):
             mask = time_value.mask
             ismasked = True
         if not isscalar:
-            time_value = numpy.array(time_value, dtype='d')
+            time_value = np.array(time_value, dtype='d')
             shape = time_value.shape
         # convert to desired units, subtract time zone offset.
         if self.units in microsec_units:
@@ -1213,7 +1212,7 @@ units to datetime objects.
         if isscalar:
             return date
         else:
-            return numpy.reshape(numpy.array(date), shape)
+            return np.reshape(np.array(date), shape)
 
 
 cdef _parse_timezone(tzstring):
@@ -1314,23 +1313,23 @@ cdef _check_index(indices, times, nctime, calendar, select):
 #       t.append(nctime[ind])
 
     if select == 'exact':
-        return numpy.all(t == times)
+        return np.all(t == times)
 
     elif select == 'before':
-        ta = nctime[numpy.clip(indices + 1, 0, N - 1)]
-        return numpy.all(t <= times) and numpy.all(ta > times)
+        ta = nctime[np.clip(indices + 1, 0, N - 1)]
+        return np.all(t <= times) and np.all(ta > times)
 
     elif select == 'after':
-        tb = nctime[numpy.clip(indices - 1, 0, N - 1)]
-        return numpy.all(t >= times) and numpy.all(tb < times)
+        tb = nctime[np.clip(indices - 1, 0, N - 1)]
+        return np.all(t >= times) and np.all(tb < times)
 
     elif select == 'nearest':
-        ta = nctime[numpy.clip(indices + 1, 0, N - 1)]
-        tb = nctime[numpy.clip(indices - 1, 0, N - 1)]
+        ta = nctime[np.clip(indices + 1, 0, N - 1)]
+        tb = nctime[np.clip(indices - 1, 0, N - 1)]
         delta_after = ta - t
         delta_before = t - tb
-        delta_check = numpy.abs(times - t)
-        return numpy.all(delta_check <= delta_after) and numpy.all(delta_check <= delta_before)
+        delta_check = np.abs(times - t)
+        return np.all(delta_check <= delta_after) and np.all(delta_check <= delta_before)
 
 
 def _date2index(dates, nctime, calendar=None, select='exact'):
@@ -1406,7 +1405,7 @@ def time2index(times, nctime, calendar=None, select='exact'):
     if calendar == None:
         calendar = getattr(nctime, 'calendar', 'standard')
 
-    num = numpy.atleast_1d(times)
+    num = np.atleast_1d(times)
     N = len(nctime)
 
     # Trying to infer the correct index from the starting time and the stride.
@@ -1418,11 +1417,11 @@ def time2index(times, nctime, calendar=None, select='exact'):
         t0 = nctime[0]
         dt = 1.
     if select in ['exact', 'before']:
-        index = numpy.array((num - t0) / dt, int)
+        index = np.array((num - t0) / dt, int)
     elif select == 'after':
-        index = numpy.array(numpy.ceil((num - t0) / dt), int)
+        index = np.array(np.ceil((num - t0) / dt), int)
     else:
-        index = numpy.array(numpy.around((num - t0) / dt), int)
+        index = np.array(np.around((num - t0) / dt), int)
 
     # Checking that the index really corresponds to the given time.
     # If the times do not correspond, then it means that the times
@@ -1431,17 +1430,17 @@ def time2index(times, nctime, calendar=None, select='exact'):
 
         # Use the bisection method. Assumes nctime is ordered.
         import bisect
-        index = numpy.array([bisect.bisect_right(nctime, n) for n in num], int)
+        index = np.array([bisect.bisect_right(nctime, n) for n in num], int)
         before = index == 0
 
-        index = numpy.array([bisect.bisect_left(nctime, n) for n in num], int)
+        index = np.array([bisect.bisect_left(nctime, n) for n in num], int)
         after = index == N
 
-        if select in ['before', 'exact'] and numpy.any(before):
+        if select in ['before', 'exact'] and np.any(before):
             raise ValueError(
                 'Some of the times given are before the first time in `nctime`.')
 
-        if select in ['after', 'exact'] and numpy.any(after):
+        if select in ['after', 'exact'] and np.any(after):
             raise ValueError(
                 'Some of the times given are after the last time in `nctime`.')
 
@@ -1449,8 +1448,8 @@ def time2index(times, nctime, calendar=None, select='exact'):
         # Use list comprehension instead of the simpler `nctime[index]` since
         # not all time objects support numpy integer indexing (eg dap).
         index[after] = N - 1
-        ncnum = numpy.squeeze([nctime[i] for i in index])
-        mismatch = numpy.nonzero(ncnum != num)[0]
+        ncnum = np.squeeze([nctime[i] for i in index])
+        mismatch = np.nonzero(ncnum != num)[0]
 
         if select == 'exact':
             if len(mismatch) > 0:
@@ -1465,7 +1464,7 @@ def time2index(times, nctime, calendar=None, select='exact'):
             pass
 
         elif select == 'nearest':
-            nearest_to_left = num[mismatch] < numpy.array(
+            nearest_to_left = num[mismatch] < np.array(
                 [float(nctime[i - 1]) + float(nctime[i]) for i in index[mismatch]]) / 2.
             index[mismatch] = index[mismatch] - 1 * nearest_to_left
 

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -5,6 +5,8 @@ Performs conversions of netCDF time coordinate data to/from datetime objects.
 from cpython.object cimport PyObject_RichCompare
 import cython
 import numpy as np
+import math
+import numpy
 import re
 import time
 from datetime import datetime as real_datetime
@@ -142,12 +144,12 @@ def date2num(dates,units,calendar='standard'):
             except:
                 isscalar = True
             if isscalar:
-                dates = np.array([dates])
+                dates = numpy.array([dates])
             else:
-                dates = np.array(dates)
+                dates = numpy.array(dates)
                 shape = dates.shape
             ismasked = False
-            if np.ma.isMA(dates) and np.ma.is_masked(dates):
+            if numpy.ma.isMA(dates) and numpy.ma.is_masked(dates):
                 mask = dates.mask
                 ismasked = True
             times = []
@@ -175,7 +177,7 @@ def date2num(dates,units,calendar='standard'):
             if isscalar:
                 return times[0]
             else:
-                return np.reshape(np.array(times), shape)
+                return numpy.reshape(numpy.array(times), shape)
         else: # use cftime module for other calendars
             cdftime = utime(units,calendar=calendar)
             return cdftime.date2num(dates)
@@ -233,7 +235,7 @@ def num2date(times,units,calendar='standard',only_use_cftime_datetimes=False):
             msg='negative reference year in time units, must be >= 1'
             raise ValueError(msg)
 
-    postimes =  (np.asarray(times) > 0).all() # netcdf4-python issue #659
+    postimes =  (numpy.asarray(times) > 0).all() # netcdf4-python issue #659
     if only_use_cftime_datetimes:
         cdftime = utime(units, calendar=calendar,
                         only_use_cftime_datetimes=only_use_cftime_datetimes)
@@ -247,12 +249,12 @@ def num2date(times,units,calendar='standard',only_use_cftime_datetimes=False):
         except:
             isscalar = True
         if isscalar:
-            times = np.array([times],dtype='d')
+            times = numpy.array([times],dtype='d')
         else:
-            times = np.array(times, dtype='d')
+            times = numpy.array(times, dtype='d')
             shape = times.shape
         ismasked = False
-        if np.ma.isMA(times) and np.ma.is_masked(times):
+        if numpy.ma.isMA(times) and numpy.ma.is_masked(times):
             mask = times.mask
             ismasked = True
         dates = []
@@ -279,7 +281,7 @@ def num2date(times,units,calendar='standard',only_use_cftime_datetimes=False):
                 days = tsecs // 86400.
                 msecsd = tsecs*1.e6 - days*86400.*1.e6
                 secs = msecsd // 1.e6
-                msecs = np.round(msecsd - secs*1.e6)
+                msecs = numpy.round(msecsd - secs*1.e6)
                 td = timedelta(days=days,seconds=secs,microseconds=msecs)
                 # add time delta to base date.
                 date = basedate + td
@@ -287,7 +289,7 @@ def num2date(times,units,calendar='standard',only_use_cftime_datetimes=False):
         if isscalar:
             return dates[0]
         else:
-            return np.reshape(np.array(dates), shape)
+            return numpy.reshape(numpy.array(dates), shape)
     else: # use cftime for other calendars
         cdftime = utime(units,calendar=calendar)
         return cdftime.num2date(times)
@@ -572,7 +574,7 @@ def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=False):
 
     # based on redate.py by David Finlayson.
 
-    julian = np.array(JD, dtype=np.float64)
+    julian = np.array(JD, dtype=float)
 
     if np.min(julian) < 0:
         raise ValueError('Julian Day must be positive')
@@ -580,14 +582,13 @@ def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=False):
     dayofwk = np.atleast_1d(np.int32(np.fmod(np.int32(julian + 1.5), 7)))
     # get the day (Z) and the fraction of the day (F)
     # add 0.000005 which is 452 ms in case of jd being after
-    # second 23:59:59 of a day we want to round to the next day
-    # (see netcdf4-python issue #75, also cftime issue #49)
-    Z = np.atleast_1d(np.int32(np.round(julian+0.000005)))
+    # second 23:59:59 of a day we want to round to the next day see issue #75
+    Z = np.atleast_1d(np.int32(np.round(julian)))
     F = np.atleast_1d(julian + 0.5 - Z).astype(np.float64)
     if calendar in ['standard', 'gregorian']:
         # MC
-        #alpha = np.int32((Z - 1867216.25)/36524.25)
-        #A = Z + 1 + alpha - np.int32(alpha/4)
+        # alpha = int((Z - 1867216.25)/36524.25)
+        # A = Z + 1 + alpha - int(alpha/4)
         alpha = np.int32(((Z - 1867216.) - 0.25) / 36524.25)
         A = Z + 1 + alpha - np.int32(0.25 * alpha)
         # check if dates before oct 5th 1582 are in the array
@@ -609,8 +610,8 @@ def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=False):
 
     B = A + 1524
     # MC
-    #C = np.atleast_1d(np.int32((B - 122.1)/365.25))
-    #D = np.atleast_1d(np.int32(365.25 * C))
+    # C = int((B - 122.1)/365.25)
+    # D = int(365.25 * C)
     C = np.atleast_1d(np.int32(6680. + ((B - 2439870.) - 122.1) / 365.25))
     D = np.atleast_1d(np.int32(365 * C + np.int32(0.25 * C)))
     E = np.atleast_1d(np.int32((B - D) / 30.6001))
@@ -731,8 +732,8 @@ days. Julian Day is a fractional day with approximately millisecond accuracy.
     else:
         year_offset = 0
 
-    dayofwk = int(np.fmod(int(JD + 1.5), 7))
-    (F, Z) = np.modf(JD + 0.5)
+    dayofwk = int(math.fmod(int(JD + 1.5), 7))
+    (F, Z) = math.modf(JD + 0.5)
     Z = int(Z)
     A = Z
     B = A + 1524
@@ -758,10 +759,10 @@ days. Julian Day is a fractional day with approximately millisecond accuracy.
         year = C - 4715
 
     # Convert fractions of a day to time
-    (dfrac, days) = np.modf(day / 1.0)
-    (hfrac, hours) = np.modf(dfrac * 24.0)
-    (mfrac, minutes) = np.modf(hfrac * 60.0)
-    (sfrac, seconds) = np.modf(mfrac * 60.0)
+    (dfrac, days) = math.modf(day / 1.0)
+    (hfrac, hours) = math.modf(dfrac * 24.0)
+    (mfrac, minutes) = math.modf(hfrac * 60.0)
+    (sfrac, seconds) = math.modf(mfrac * 60.0)
     microseconds = sfrac*1.e6
 
     if year_offset > 0:
@@ -769,7 +770,7 @@ days. Julian Day is a fractional day with approximately millisecond accuracy.
 
         # 365 mod 7 = 1, so the day of the week changes by one day for
         # every year in year_offset
-        dayofwk -= int(np.fmod(year_offset, 7))
+        dayofwk -= int(math.fmod(year_offset, 7))
 
         if dayofwk < 0:
             dayofwk += 7
@@ -792,8 +793,8 @@ Julian Day is a fractional day with approximately millisecond accuracy.
     if JD < 0:
         raise ValueError('Julian Day must be positive')
 
-    dayofwk = int(np.fmod(int(JD + 1.5), 7))
-    (F, Z) = np.modf(JD + 0.5)
+    dayofwk = int(math.fmod(int(JD + 1.5), 7))
+    (F, Z) = math.modf(JD + 0.5)
     Z = int(Z)
     A = Z
     B = A + 1524
@@ -821,10 +822,10 @@ Julian Day is a fractional day with approximately millisecond accuracy.
         year = C - 4715
 
     # Convert fractions of a day to time
-    (dfrac, days) = np.modf(day / 1.0)
-    (hfrac, hours) = np.modf(dfrac * 24.0)
-    (mfrac, minutes) = np.modf(hfrac * 60.0)
-    (sfrac, seconds) = np.modf(mfrac * 60.0)
+    (dfrac, days) = math.modf(day / 1.0)
+    (hfrac, hours) = math.modf(dfrac * 24.0)
+    (mfrac, minutes) = math.modf(hfrac * 60.0)
+    (sfrac, seconds) = math.modf(mfrac * 60.0)
     microseconds = sfrac*1.e6
 
     return DatetimeAllLeap(year, month, int(days), int(hours), int(minutes),
@@ -847,17 +848,17 @@ Julian Day is a fractional day with approximately millisecond accuracy.
         year_offset = 0
 
     #jd = int(360. * (year + 4716)) + int(30. * (month - 1)) + day
-    (F, Z) = np.modf(JD)
+    (F, Z) = math.modf(JD)
     year = int((Z - 0.5) / 360.) - 4716
     dayofyr = Z - (year + 4716) * 360
     month = int((dayofyr - 0.5) / 30) + 1
     day = dayofyr - (month - 1) * 30 + F
 
     # Convert fractions of a day to time
-    (dfrac, days) = np.modf(day / 1.0)
-    (hfrac, hours) = np.modf(dfrac * 24.0)
-    (mfrac, minutes) = np.modf(hfrac * 60.0)
-    (sfrac, seconds) = np.modf(mfrac * 60.0)
+    (dfrac, days) = math.modf(day / 1.0)
+    (hfrac, hours) = math.modf(dfrac * 24.0)
+    (mfrac, minutes) = math.modf(hfrac * 60.0)
+    (sfrac, seconds) = math.modf(mfrac * 60.0)
     microseconds = sfrac*1.e6
 
     return Datetime360Day(year - year_offset, month, int(days), int(hours), int(minutes),
@@ -1064,7 +1065,7 @@ units to datetime objects.
         except:
             isscalar = True
         if not isscalar:
-            date = np.array(date)
+            date = numpy.array(date)
             shape = date.shape
         if self.calendar in ['julian', 'standard', 'gregorian', 'proleptic_gregorian']:
             if isscalar:
@@ -1104,7 +1105,7 @@ units to datetime objects.
                             'there are only 30 days in every month with the 360_day calendar')
                     jdelta.append(_360DayFromDate(d) - self._jd0)
         if not isscalar:
-            jdelta = np.array(jdelta)
+            jdelta = numpy.array(jdelta)
         # convert to desired units, add time zone offset.
         if self.units in microsec_units:
             jdelta = jdelta * 86400. * 1.e6  + self.tzoffset * 60. * 1.e6
@@ -1123,7 +1124,7 @@ units to datetime objects.
         if isscalar:
             return jdelta
         else:
-            return np.reshape(jdelta, shape)
+            return numpy.reshape(jdelta, shape)
 
     def num2date(self, time_value):
         """
@@ -1153,11 +1154,11 @@ units to datetime objects.
         except:
             isscalar = True
         ismasked = False
-        if np.ma.isMA(time_value) and np.ma.is_masked(time_value):
+        if numpy.ma.isMA(time_value) and numpy.ma.is_masked(time_value):
             mask = time_value.mask
             ismasked = True
         if not isscalar:
-            time_value = np.array(time_value, dtype='d')
+            time_value = numpy.array(time_value, dtype='d')
             shape = time_value.shape
         # convert to desired units, subtract time zone offset.
         if self.units in microsec_units:
@@ -1212,7 +1213,7 @@ units to datetime objects.
         if isscalar:
             return date
         else:
-            return np.reshape(np.array(date), shape)
+            return numpy.reshape(numpy.array(date), shape)
 
 
 cdef _parse_timezone(tzstring):
@@ -1313,23 +1314,23 @@ cdef _check_index(indices, times, nctime, calendar, select):
 #       t.append(nctime[ind])
 
     if select == 'exact':
-        return np.all(t == times)
+        return numpy.all(t == times)
 
     elif select == 'before':
-        ta = nctime[np.clip(indices + 1, 0, N - 1)]
-        return np.all(t <= times) and np.all(ta > times)
+        ta = nctime[numpy.clip(indices + 1, 0, N - 1)]
+        return numpy.all(t <= times) and numpy.all(ta > times)
 
     elif select == 'after':
-        tb = nctime[np.clip(indices - 1, 0, N - 1)]
-        return np.all(t >= times) and np.all(tb < times)
+        tb = nctime[numpy.clip(indices - 1, 0, N - 1)]
+        return numpy.all(t >= times) and numpy.all(tb < times)
 
     elif select == 'nearest':
-        ta = nctime[np.clip(indices + 1, 0, N - 1)]
-        tb = nctime[np.clip(indices - 1, 0, N - 1)]
+        ta = nctime[numpy.clip(indices + 1, 0, N - 1)]
+        tb = nctime[numpy.clip(indices - 1, 0, N - 1)]
         delta_after = ta - t
         delta_before = t - tb
-        delta_check = np.abs(times - t)
-        return np.all(delta_check <= delta_after) and np.all(delta_check <= delta_before)
+        delta_check = numpy.abs(times - t)
+        return numpy.all(delta_check <= delta_after) and numpy.all(delta_check <= delta_before)
 
 
 def _date2index(dates, nctime, calendar=None, select='exact'):
@@ -1405,7 +1406,7 @@ def time2index(times, nctime, calendar=None, select='exact'):
     if calendar == None:
         calendar = getattr(nctime, 'calendar', 'standard')
 
-    num = np.atleast_1d(times)
+    num = numpy.atleast_1d(times)
     N = len(nctime)
 
     # Trying to infer the correct index from the starting time and the stride.
@@ -1417,11 +1418,11 @@ def time2index(times, nctime, calendar=None, select='exact'):
         t0 = nctime[0]
         dt = 1.
     if select in ['exact', 'before']:
-        index = np.array((num - t0) / dt, int)
+        index = numpy.array((num - t0) / dt, int)
     elif select == 'after':
-        index = np.array(np.ceil((num - t0) / dt), int)
+        index = numpy.array(numpy.ceil((num - t0) / dt), int)
     else:
-        index = np.array(np.around((num - t0) / dt), int)
+        index = numpy.array(numpy.around((num - t0) / dt), int)
 
     # Checking that the index really corresponds to the given time.
     # If the times do not correspond, then it means that the times
@@ -1430,17 +1431,17 @@ def time2index(times, nctime, calendar=None, select='exact'):
 
         # Use the bisection method. Assumes nctime is ordered.
         import bisect
-        index = np.array([bisect.bisect_right(nctime, n) for n in num], int)
+        index = numpy.array([bisect.bisect_right(nctime, n) for n in num], int)
         before = index == 0
 
-        index = np.array([bisect.bisect_left(nctime, n) for n in num], int)
+        index = numpy.array([bisect.bisect_left(nctime, n) for n in num], int)
         after = index == N
 
-        if select in ['before', 'exact'] and np.any(before):
+        if select in ['before', 'exact'] and numpy.any(before):
             raise ValueError(
                 'Some of the times given are before the first time in `nctime`.')
 
-        if select in ['after', 'exact'] and np.any(after):
+        if select in ['after', 'exact'] and numpy.any(after):
             raise ValueError(
                 'Some of the times given are after the last time in `nctime`.')
 
@@ -1448,8 +1449,8 @@ def time2index(times, nctime, calendar=None, select='exact'):
         # Use list comprehension instead of the simpler `nctime[index]` since
         # not all time objects support numpy integer indexing (eg dap).
         index[after] = N - 1
-        ncnum = np.squeeze([nctime[i] for i in index])
-        mismatch = np.nonzero(ncnum != num)[0]
+        ncnum = numpy.squeeze([nctime[i] for i in index])
+        mismatch = numpy.nonzero(ncnum != num)[0]
 
         if select == 'exact':
             if len(mismatch) > 0:
@@ -1464,7 +1465,7 @@ def time2index(times, nctime, calendar=None, select='exact'):
             pass
 
         elif select == 'nearest':
-            nearest_to_left = num[mismatch] < np.array(
+            nearest_to_left = num[mismatch] < numpy.array(
                 [float(nctime[i - 1]) + float(nctime[i]) for i in index[mismatch]]) / 2.
             index[mismatch] = index[mismatch] - 1 * nearest_to_left
 

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -561,6 +561,14 @@ class cftimeTestCase(unittest.TestCase):
         n = date2num(utc_date, units, calendar="julian")
         # n should always be 0 as all units refer to the same point in time
         assert_almost_equal(n, 0)
+        # cftime issue #49
+        d = DateFromJulianDay(2450022.5, "standard")
+        assert (d.year == 1995)
+        assert (d.month == 11)
+        assert (d.day == 1)
+        assert (d.hour == 0)
+        assert (d.minute == 0)
+        assert (d.second == 0)
 
 
 class TestDate2index(unittest.TestCase):
@@ -745,7 +753,6 @@ class TestDate2index(unittest.TestCase):
         # calculation of nearest index when sum of adjacent
         # time values won't fit in 32 bits.
         query_time = datetime(2037, 1, 3, 21, 12)
-        print(self.time_vars['time3'])
         index = date2index(query_time, self.time_vars['time3'],
                            select='nearest')
         assert(index == 11)
@@ -1043,13 +1050,13 @@ class issue17TestCase(unittest.TestCase):
 
 class issue57TestCase(unittest.TestCase):
     """Regression tests for issue #57."""
-    # issue 57: cftime._cftime._dateparse returns quite opaque error messages that make it difficult to 
+    # issue 57: cftime._cftime._dateparse returns quite opaque error messages that make it difficult to
     # track down the source of problem
     def setUp(self):
         pass
 
     def test_parse_incorrect_unitstring(self):
-        for datestr in ("days since2017-05-01 ", "dayssince 2017-05-01 00:00", "days snce 2017-05-01 00:00", "days_since_2017-05-01 00:00", 
+        for datestr in ("days since2017-05-01 ", "dayssince 2017-05-01 00:00", "days snce 2017-05-01 00:00", "days_since_2017-05-01 00:00",
             "days_since_2017-05-01_00:00"):
             self.assertRaises(
                 ValueError, cftime._cftime._dateparse, datestr)

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -569,6 +569,21 @@ class cftimeTestCase(unittest.TestCase):
         assert (d.hour == 0)
         assert (d.minute == 0)
         assert (d.second == 0)
+        # cftime issue #52
+        d = DateFromJulianDay(1684958.5,calendar='gregorian')
+        assert (d.year == -100)
+        assert (d.month == 3)
+        assert (d.day == 2)
+        assert (d.hour == 0)
+        assert (d.minute == 0)
+        assert (d.second == 0)
+        d = DateFromJulianDay(1684958.5,calendar='standard')
+        assert (d.year == -100)
+        assert (d.month == 3)
+        assert (d.day == 2)
+        assert (d.hour == 0)
+        assert (d.minute == 0)
+        assert (d.second == 0)
 
 
 class TestDate2index(unittest.TestCase):

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -561,14 +561,6 @@ class cftimeTestCase(unittest.TestCase):
         n = date2num(utc_date, units, calendar="julian")
         # n should always be 0 as all units refer to the same point in time
         assert_almost_equal(n, 0)
-        # cftime issue #49
-        d = DateFromJulianDay(2450022.5, "standard")
-        assert (d.year == 1995)
-        assert (d.month == 11)
-        assert (d.day == 1)
-        assert (d.hour == 0)
-        assert (d.minute == 0)
-        assert (d.second == 0)
 
 
 class TestDate2index(unittest.TestCase):
@@ -753,6 +745,7 @@ class TestDate2index(unittest.TestCase):
         # calculation of nearest index when sum of adjacent
         # time values won't fit in 32 bits.
         query_time = datetime(2037, 1, 3, 21, 12)
+        print(self.time_vars['time3'])
         index = date2index(query_time, self.time_vars['time3'],
                            select='nearest')
         assert(index == 11)
@@ -1050,13 +1043,13 @@ class issue17TestCase(unittest.TestCase):
 
 class issue57TestCase(unittest.TestCase):
     """Regression tests for issue #57."""
-    # issue 57: cftime._cftime._dateparse returns quite opaque error messages that make it difficult to
+    # issue 57: cftime._cftime._dateparse returns quite opaque error messages that make it difficult to 
     # track down the source of problem
     def setUp(self):
         pass
 
     def test_parse_incorrect_unitstring(self):
-        for datestr in ("days since2017-05-01 ", "dayssince 2017-05-01 00:00", "days snce 2017-05-01 00:00", "days_since_2017-05-01 00:00",
+        for datestr in ("days since2017-05-01 ", "dayssince 2017-05-01 00:00", "days snce 2017-05-01 00:00", "days_since_2017-05-01 00:00", 
             "days_since_2017-05-01_00:00"):
             self.assertRaises(
                 ValueError, cftime._cftime._dateparse, datestr)


### PR DESCRIPTION
Fix was to restore the fix added in https://github.com/Unidata/netcdf4-python/issues/75, which was removed at some point because we thought it was no longer needed.  Apparently it is.

Also removed import of python `math` module, used `numpy` instead.