### PR TITLE
enable test coverage and coveralls.io

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,7 +41,7 @@ install:
 build: off
 
 test_script:
-    - conda.exe create --name TEST python=%PY% numpy=%NPY% cython pip pytest
+    - conda.exe create --name TEST python=%PY% numpy=%NPY% cython pip pytest pytest-cov
     - conda activate TEST
     - python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
     - py.test -vv test

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,21 @@
+#
+# .coveragerc to control coverage.py
+#
+
+[run]
+branch = True
+plugins = Cython.Coverage
+include =
+    cftime/*
+omit = 
+    setup.py
+    docs/*
+    ci/*
+    test/*
+    .eggs
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if __name__ == .__main__.:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.so
+*.py[co]
 *.c
 build/
+*.egg?
 *.egg-info
 _build/
 __pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,13 @@ before_install:
 install:
   # Install cftime.
   - echo "Installing cftime..."
-  - pip install -e .
+  - CYTHON_COVERAGE=1 pip install -e .
 
 script:
   - if [[ "${BUILD_DOCS}" == "true" ]]; then
       pushd docs && make html linkcheck O=-W && popd;
     else
-      py.test -vv;
+      pytest -v;
     fi;
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Time-handling functionality from netcdf4-python
 [![Linux Build Status](https://travis-ci.org/Unidata/cftime.svg?branch=master)](https://travis-ci.org/Unidata/cftime)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/fl9taa9je4e6wi7n/branch/master?svg=true)](https://ci.appveyor.com/project/jswhit/cftime/branch/master)
 [![PyPI package](https://badge.fury.io/py/cftime.svg)](http://python.org/pypi/cftime)
+[![Coverage Status](https://coveralls.io/repos/github/Unidata/cftime/badge.svg?branch=master)](https://coveralls.io/github/Unidata/cftime?branch=master)
 
 ## News
 10/27/2018:  version 1.0.2 released. Improved accuracy (from approximately 1000 microseconds to 10 microseconds on x86

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
+coverage
+coveralls
 cython
 pytest
-coveralls
 pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[tool:pytest]
+testpaths = test
+addopts = 
+    -ra
+    --doctest-modules
+    --cov-config .coveragerc
+    --cov=cftime
+    --cov-report term-missing
+doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,48 @@
+from __future__ import print_function
+
 import os
+import sys
 
-from setuptools import Extension, setup
+from Cython.Build import cythonize
+from setuptools import Command, Extension, setup
 
-rootpath = os.path.abspath(os.path.dirname(__file__))
+
+COMPILER_DIRECTIVES = {}
+DEFINE_MACROS = None
+FLAG_COVERAGE = '--cython-coverage'  # custom flag enabling Cython line tracing
+BASEDIR = os.path.abspath(os.path.dirname(__file__))
+NAME = 'cftime'
+CFTIME_DIR = os.path.join(BASEDIR, NAME)
+CYTHON_FNAME = os.path.join(CFTIME_DIR, '_{}.pyx'.format(NAME))
 
 
-def extract_version(module='cftime'):
+class CleanCython(Command):
+    description = 'Purge artifacts built by Cython'
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        for rpath, _, fnames in os.walk(CFTIME_DIR):
+            for fname in fnames:
+                _, ext = os.path.splitext(fname)
+                if ext in ('.pyc', '.pyo', '.c', '.so'):
+                    artifact = os.path.join(rpath, fname)
+                    if os.path.exists(artifact):
+                        print('clean: removing file {!r}'.format(artifact))
+                        os.remove(artifact)
+                    else:
+                        print('clean: skipping file {!r}'.format(artifact))
+
+
+def extract_version():
     version = None
-    fname = os.path.join(rootpath, module, '_cftime.pyx')
-    with open(fname) as f:
-        for line in f:
+    with open(CYTHON_FNAME) as fi:
+        for line in fi:
             if (line.startswith('__version__')):
                 _, version = line.split('=')
                 version = version.strip()[1:-1]  # Remove quotation characters.
@@ -17,22 +50,48 @@ def extract_version(module='cftime'):
     return version
 
 
-with open('requirements.txt') as f:
-    reqs = f.readlines()
-install_requires = [req.strip() for req in reqs]
+def load(fname):
+    result = []
+    with open(fname, 'r') as fi:
+        result = [package.strip() for package in fi.readlines()]
+    return result
 
-with open('requirements-dev.txt') as f:
-    reqs = f.readlines()
-tests_require = [req.strip() for req in reqs]
+
+def description():
+    fname = os.path.join(BASEDIR, 'README.md')
+    with open(fname, 'r') as fi:
+        result = ''.join(fi.readlines())
+    return result
+
+
+if FLAG_COVERAGE in sys.argv or os.environ.get('CYTHON_COVERAGE', None):
+    COMPILER_DIRECTIVES = {'linetrace': True,
+                           'warn.maybe_uninitialized': False,
+                           'warn.unreachable': False,
+                           'warn.unused': False}
+    DEFINE_MACROS = [('CYTHON_TRACE', '1'),
+                     ('CYTHON_TRACE_NOGIL', '1')]
+    if FLAG_COVERAGE in sys.argv:
+        sys.argv.remove(FLAG_COVERAGE)
+    print('enable: "linetrace" Cython compiler directive')
+
+extension = Extension('{}._{}'.format(NAME, NAME),
+                      sources=[CYTHON_FNAME],
+                      define_macros=DEFINE_MACROS)
 
 setup(
-    name='cftime',
+    name=NAME,
     author='Jeff Whitaker',
     author_email='jeffrey.s.whitaker@noaa.gov',
     description='Time-handling functionality from netcdf4-python',
-    packages=['cftime'],
+    long_description=description(),
+    long_description_content_type='text/markdown',
+    cmdclass={'clean_cython': CleanCython},
+    packages=[NAME],
     version=extract_version(),
-    ext_modules=[Extension('cftime._cftime', sources=['cftime/_cftime.pyx'])],
-    setup_requires=['setuptools>=18.0', 'cython>=0.19'],
-    install_requires=install_requires,
-    tests_require=tests_require)
+    ext_modules=cythonize(extension,
+                          compiler_directives=COMPILER_DIRECTIVES,
+                          language_level=2),
+    setup_requires=load('setup.txt'),
+    install_requires=load('requirements.txt'),
+    tests_require=load('requirements-dev.txt'))

--- a/setup.txt
+++ b/setup.txt
@@ -1,0 +1,2 @@
+cython>=0.19
+setuptools>=18.0

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -686,10 +686,6 @@ class TestDate2index(unittest.TestCase):
             and `step` define the starting date, the length of the array and
             the distance between each date (in units).
 
-            :Example:
-            >>> t = TestTime(datetime(1989, 2, 18), 45, 6, 'hours since 1979-01-01')
-            >>> print num2date(t[1], t.units)
-            1989-02-18 06:00:00
             """
             self.units = units
             self.calendar = calendar


### PR DESCRIPTION
This PR turns-on the `pytest` coverage. 

In addition, it also provides coverage of the Cython `.pyx`... which took a but of figuring out.

If you enable `coveralls.io` for the repo, you can get analysis of the coverage, but unfortunately `coveralls.io` is not picking up the `*.pyx`, which is a shame, but `pytest-cov` appears to be working just fine.