### PR TITLE
fix travis command not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ script:
   - if [[ "${BUILD_DOCS}" == "true" ]]; then
       pushd docs && make html linkcheck O=-W && popd;
     else
-      pytest -v;
-    fi;
+      pytest;
+    fi
 
 after_success:
   - coveralls
@@ -65,4 +65,4 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-      condition: '${PYTHON_VERSION} == 3.7 AND ${BUILD_DOCS} == "true"'
+      condition: '${PYTHON_VERSION} == 3.7 && ${BUILD_DOCS} == "true"'

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 testpaths = test
 addopts = 
     -ra
+    -v
     --doctest-modules
     --cov-config .coveragerc
     --cov=cftime


### PR DESCRIPTION
The PR hopefully finishes the job I started...

I noticed that the coveralls.io badge in the `README.md` is reporting `unknown` coverage :cry:

After sneaking a peek at the `.travis.yml` and the last `master` job on `travis-ci` it appears that in my previous PRs I've introduced some bad syntax, that's resulting in the `after_success: coveralls` command not running i.e.

```
<snip>
=================== 563 passed, 1 skipped in 164.15 seconds ====================
travis_time:end:1b8998e0:start=1543679107151552856,finish=1543679271838209175,duration=164686656319
The command "if [[ "${BUILD_DOCS}" == "true" ]]; then pushd docs && make html linkcheck O=-W && popd; else pytest -v; fi;" exited with 0.


travis_run_after_success: command not found
travis_run_after_failure: command not found
travis_run_after_script: command not found
travis_run_finish: command not found

Done. Your build exited with 0.
```

Oops. Also the `travis-ci` worker was also complaining with:

```
worker_info
[0K/home/travis/.travis/job_stages: line 1028: expected `)'
/home/travis/.travis/job_stages: line 1028: syntax error near `AND'
/home/travis/.travis/job_stages: line 1028: `  if [[ ($TRAVIS_BRANCH = master) && (${PYTHON_VERSION} == 3.7 AND ${BUILD_DOCS} == "true") ]]; then'
```

This PR attempts to fix this, with `travis-ci` successfully pushing test coverage to coveralls.io, resulting in a badge update.