### PR TITLE
replace time.clock() with time.perf_count() for python 3.8

### DIFF
--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -42,7 +42,7 @@ cdef int[13] _spm_366day = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 33
 _rop_lookup = {Py_LT: '__gt__', Py_LE: '__ge__', Py_EQ: '__eq__',
                Py_GT: '__lt__', Py_GE: '__le__', Py_NE: '__ne__'}
 
-__version__ = '1.0.3'
+__version__ = '1.0.3.1'
 
 # Adapted from http://delete.me.uk/2005/03/iso8601.html
 # Note: This regex ensures that all ISO8601 timezone formats are accepted - but, due to legacy support for other timestrings, not all incorrect formats can be rejected.

--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -1,17 +1,20 @@
 from cftime import num2date, date2num
-import time
+try:
+    from time import perf_counter
+except ImportError:
+    from time import clock as perf_counter
 import numpy as np
 units = 'hours since 01-01-01'
 calendar = 'standard'
 timevals = np.arange(0,10000,1)
 print('processing %s values...' % len(timevals))
-t1 = time.clock()
+t1 = perf_counter()
 dates =\
 num2date(timevals,units=units,calendar=calendar,only_use_cftime_datetimes=True)
-t2 = time.clock()
+t2 = perf_counter()
 t = t2-t1
 print('num2date took %s seconds' % t)
 timevals2 = date2num(dates,units=units,calendar=calendar)
-t1 = time.clock()
+t1 = perf_counter()
 t = t1-t2
 print('date2num took %s seconds' % t)


### PR DESCRIPTION
also bump version number to 1.0.3.1