### PR TITLE
No longer support replacing dayofwk and dayofyr

### DIFF
--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -1220,9 +1220,7 @@ Gregorial calendar.
                 "hour": self.hour,
                 "minute": self.minute,
                 "second": self.second,
-                "microsecond": self.microsecond,
-                "dayofwk": self.dayofwk,
-                "dayofyr": self.dayofyr}
+                "microsecond": self.microsecond}
 
         for name, value in kwargs.items():
             args[name] = value

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -1222,6 +1222,10 @@ Gregorial calendar.
                 "second": self.second,
                 "microsecond": self.microsecond}
 
+        if 'dayofyr' in kwargs or 'dayofwk' in kwargs:
+            raise ValueError('Replacing the dayofyr or dayofwk of a datetime is '
+                             'not supported.')
+
         for name, value in kwargs.items():
             args[name] = value
 

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1043,8 +1043,6 @@ class DateTime(unittest.TestCase):
         self.assertEqual(self.date1_365_day.replace(minute=3).minute, 3)
         self.assertEqual(self.date1_365_day.replace(second=3).second, 3)
         self.assertEqual(self.date1_365_day.replace(microsecond=3).microsecond, 3)
-        self.assertEqual(self.date1_365_day.replace(dayofwk=3).dayofwk, 3)
-        self.assertEqual(self.date1_365_day.replace(dayofyr=3).dayofyr, 3)
 
     def test_pickling(self):
         "Test reversibility of pickling."
@@ -1426,6 +1424,20 @@ def test_repr():
     expected = 'cftime.DatetimeGregorian(2000, 1, 1, 0, 0, 0, 0, 5, 1)'
     # dayofwk, dayofyr are set
     assert repr(DatetimeGregorian(2000, 1, 1)) == expected
+
+
+def test_dayofyr_replace(date_type):
+    date = date_type(1, 1, 1)
+    assert date.dayofyr == 1
+    assert date.replace(day=2).dayofyr == 2
+
+
+def test_dayofwk_replace(date_type):
+    date = date_type(1, 1, 1)
+    original_dayofwk = date.dayofwk
+    expected = (original_dayofwk + 1) % 7
+    result = date.replace(day=2).dayofwk
+    assert result == expected
 
 
 if __name__ == '__main__':

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1426,13 +1426,13 @@ def test_repr():
     assert repr(DatetimeGregorian(2000, 1, 1)) == expected
 
 
-def test_dayofyr_replace(date_type):
+def test_dayofyr_after_replace(date_type):
     date = date_type(1, 1, 1)
     assert date.dayofyr == 1
     assert date.replace(day=2).dayofyr == 2
 
 
-def test_dayofwk_replace(date_type):
+def test_dayofwk_after_replace(date_type):
     date = date_type(1, 1, 1)
     original_dayofwk = date.dayofwk
     expected = (original_dayofwk + 1) % 7
@@ -1441,7 +1441,7 @@ def test_dayofwk_replace(date_type):
 
 
 @pytest.mark.parametrize('argument', ['dayofyr', 'dayofwk'])
-def test_replace_dayofyr_dayofwk_error(date_type, argument):
+def test_replace_dayofyr_or_dayofwk_error(date_type, argument):
     with pytest.raises(ValueError):
         date_type(1, 1, 1).replace(**{argument: 3})
 

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1440,5 +1440,11 @@ def test_dayofwk_replace(date_type):
     assert result == expected
 
 
+@pytest.mark.parametrize('argument', ['dayofyr', 'dayofwk'])
+def test_replace_dayofyr_dayofwk_error(date_type, argument):
+    with pytest.raises(ValueError):
+        date_type(1, 1, 1).replace(**{argument: 3})
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #106

Thanks @jswhit -- this is sort of what I had in mind.  Here I simply no longer propagate the old `dayofyr` and `dayofwk` attributes from the original date to the new one.  I'm not sure if there was a use-case for replacing the `dayofyr` and `dayofwk` attributes of a date, since they are intrinsic properties of a given datetime.

I added a couple tests to this implementation too.  I'm happy to make any changes if you have any comments. 