### PR TITLE
Feature tzaware

### DIFF
--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -10,7 +10,7 @@ import re
 import sys
 import time
 from datetime import datetime as datetime_python
-from datetime import timedelta, MINYEAR
+from datetime import timedelta, MINYEAR, timezone
 import time                     # strftime
 try:
     from itertools import izip as zip
@@ -182,6 +182,9 @@ def date2num(dates,units,calendar='standard'):
                 ismasked = True
             times = []
             for date in dates.flat:
+                if getattr(date, 'tzinfo') is not None:
+                    date = date.astimezone(timezone.utc).replace(tzinfo=None)
+
                 if ismasked and not date:
                     times.append(None)
                 else:
@@ -408,6 +411,9 @@ def JulianDayFromDate(date, calendar='standard'):
     cdef Py_ssize_t i
     for i in range(i_max):
         d = date[i]
+        if getattr(d, 'tzinfo', None) is not None:
+            d = d.astimezone(timezone.utc).replace(tzinfo=None)
+
         year[i] = d.year
         month[i] = d.month
         day[i] = d.day

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -10,32 +10,13 @@ import re
 import sys
 import time
 from datetime import datetime as datetime_python
-from datetime import timedelta, MINYEAR, tzinfo
+from datetime import timedelta, MINYEAR
 import time                     # strftime
 try:
     from itertools import izip as zip
 except ImportError:  # python 3.x
     pass
 
-try:
-    from datetime import timezone
-    datetime_utc = timezone.utc
-except ImportError: # python 2.7
-    class UTC(tzinfo):
-        """
-	UTC adapted from 
-        https://docs.python.org/2.7/library/datetime.html#tzinfo-objects
-	"""
-        def utcoffset(self, dt):
-            return timedelta(0)
-
-        def tzname(self, dt):
-            return "UTC"
-
-        def dst(self, dt):
-            return timedelta(0)
-
-    datetime_utc = UTC()
 
 microsec_units = ['microseconds','microsecond', 'microsec', 'microsecs']
 millisec_units = ['milliseconds', 'millisecond', 'millisec', 'millisecs']
@@ -203,7 +184,7 @@ def date2num(dates,units,calendar='standard'):
             times = []
             for date in dates.flat:
                 if getattr(date, 'tzinfo') is not None:
-                    date = date.astimezone(datetime_utc).replace(tzinfo=None)
+                    date = date.replace(tzinfo=None) - date.utcoffset()
 
                 if ismasked and not date:
                     times.append(None)
@@ -432,7 +413,7 @@ def JulianDayFromDate(date, calendar='standard'):
     for i in range(i_max):
         d = date[i]
         if getattr(d, 'tzinfo', None) is not None:
-            d = d.astimezone(datetime_utc).replace(tzinfo=None)
+            d = d.replace(tzinfo=None) - d.utcoffset()
 
         year[i] = d.year
         month[i] = d.month

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -10,12 +10,32 @@ import re
 import sys
 import time
 from datetime import datetime as datetime_python
-from datetime import timedelta, MINYEAR, timezone
+from datetime import timedelta, MINYEAR, tzinfo
 import time                     # strftime
 try:
     from itertools import izip as zip
 except ImportError:  # python 3.x
     pass
+
+try:
+    from datetime import timezone
+    datetime_utc = timezone.utc
+except ImportError: # python 2.7
+    class UTC(tzinfo):
+        """
+	UTC adapted from 
+        https://docs.python.org/2.7/library/datetime.html#tzinfo-objects
+	"""
+        def utcoffset(self, dt):
+            return timedelta(0)
+
+        def tzname(self, dt):
+            return "UTC"
+
+        def dst(self, dt):
+            return timedelta(0)
+
+    datetime_utc = UTC()
 
 microsec_units = ['microseconds','microsecond', 'microsec', 'microsecs']
 millisec_units = ['milliseconds', 'millisecond', 'millisec', 'millisecs']
@@ -183,7 +203,7 @@ def date2num(dates,units,calendar='standard'):
             times = []
             for date in dates.flat:
                 if getattr(date, 'tzinfo') is not None:
-                    date = date.astimezone(timezone.utc).replace(tzinfo=None)
+                    date = date.astimezone(datetime_utc).replace(tzinfo=None)
 
                 if ismasked and not date:
                     times.append(None)
@@ -412,7 +432,7 @@ def JulianDayFromDate(date, calendar='standard'):
     for i in range(i_max):
         d = date[i]
         if getattr(d, 'tzinfo', None) is not None:
-            d = d.astimezone(timezone.utc).replace(tzinfo=None)
+            d = d.astimezone(datetime_utc).replace(tzinfo=None)
 
         year[i] = d.year
         month[i] = d.month

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -121,7 +121,7 @@ class cftimeTestCase(unittest.TestCase):
         assert_almost_equal(t2, 13865687.0)
         assert_almost_equal(t3, 13865682.0)
 
-    def runTest(self):
+    def test_tz_naive(self):
         """testing cftime"""
         # test mixed julian/gregorian calendar
         # check attributes.

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -22,6 +22,7 @@ from cftime import (DateFromJulianDay, Datetime360Day, DatetimeAllLeap,
 try:
     from datetime import timezone
 except ImportError: # python2.7
+    from datetime import tzinfo
     class timezone(tzinfo):
         """
         Fixed offset in minutes east from UTC. adapted from


### PR DESCRIPTION
Internally converting dates with timezones to naive UTC so that dates with timezones can be passed to JulianDayFromDate and date2num. Implicitly adds support to utime.date2num.

Functionality and tests have been added. Including python2.7 capabilities.