### PR TITLE
Add abbreviations of milliseconds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,11 +2,11 @@ environment:
   CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
   matrix:
     - TARGET_ARCH: x64
-      NPY: 1.15
+      NPY: 1.16
       PY: 3.6
 
     - TARGET_ARCH: x64
-      NPY: 1.15
+      NPY: 1.16
       PY: 3.7
 
 platform:

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -19,7 +19,7 @@ except ImportError:  # python 3.x
 
 
 microsec_units = ['microseconds','microsecond', 'microsec', 'microsecs']
-millisec_units = ['milliseconds', 'millisecond', 'millisec', 'millisecs']
+millisec_units = ['milliseconds', 'millisecond', 'millisec', 'millisecs', 'msec', 'msecs', 'ms']
 sec_units =      ['second', 'seconds', 'sec', 'secs', 's']
 min_units =      ['minute', 'minutes', 'min', 'mins']
 hr_units =       ['hour', 'hours', 'hr', 'hrs', 'h']


### PR DESCRIPTION
Added various abbreviations of milliseconds that are valid per Udunits, but aren't included in cftime. The current lack of support for 'msecs' is causing errors when attempting to read radar data through TDS from siphon and xarray. 