### PR TITLE
fix intersphinx entries

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,4 +4,3 @@ API
 .. automodule:: cftime
    :members: datetime, date2num, date2index, num2date, JulianDayFromDate, DatetimeJulian, DatetimeProlepticGregorian, DatetimeNoLeap, DatetimeAllLeap, DatetimeGregorian
    :show-inheritance:
-   :noindex:


### PR DESCRIPTION
fixes #132 

This populates the intersphinx entries and the index pages. I don't know whether there are other options that only enable the entries.