### PR TITLE
switch only_use_cftime_datetimes to True by default

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,0 +1,5 @@
+since version 1.0.4.2
+====================-
+ * make use_only_cftime_datetimes=True by default, so cftime datetime
+ instances are returned by default by num2date (instead of returning python
+ datetime instances where possible). Issue #136, PR #135.

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,7 @@
-since version 1.0.4.2
-====================-
+since version 1.0.4.2 release
+=============================
+ * improved execptions for time differences (issue #128, PR #131).
+ * fix intersphinx entries (issue #133, PR #133)
  * make use_only_cftime_datetimes=True by default, so cftime datetime
  instances are returned by default by num2date (instead of returning python
  datetime instances where possible). Issue #136, PR #135.

--- a/Changelog
+++ b/Changelog
@@ -1,7 +1,16 @@
-since version 1.0.4.2 release
-=============================
- * improved execptions for time differences (issue #128, PR #131).
+version 1.1.0 (not yet released)
+================================
+
+ * improved exceptions for time differences (issue #128, PR #131).
+
  * fix intersphinx entries (issue #133, PR #133)
+
  * make use_only_cftime_datetimes=True by default, so cftime datetime
- instances are returned by default by num2date (instead of returning python
- datetime instances where possible). Issue #136, PR #135.
+   instances are returned by default by num2date (instead of returning python
+   datetime instances where possible). Issue #136, PR #135.
+
+version 1.0.4.2 release
+=======================
+
+ * fix for issue #126 (date2num error when converting a DatetimeProlepticGregorian 
+   object). PR #127.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Time-handling functionality from netcdf4-python
 [![Commits Status](https://img.shields.io/github/commits-since/UniData/cftime/latest.svg)](https://github.com/UniData/cftime/commits/master)
 
 ## News
+For details on the latest updates, see the [Changelog](https://github.com/cftime/blob/master/Changelog).
+
 10/25/2019:  version 1.0.4.2 released (fix for [issue #126](https://github.com/Unidata/cftime/issues/126)).
 
 10/21/2019:  version 1.0.4 released.

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -43,7 +43,7 @@ cdef int[13] _spm_366day = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 33
 _rop_lookup = {Py_LT: '__gt__', Py_LE: '__ge__', Py_EQ: '__eq__',
                Py_GT: '__lt__', Py_GE: '__le__', Py_NE: '__ne__'}
 
-__version__ = '1.0.4.2'
+__version__ = '1.1.0'
 
 # Adapted from http://delete.me.uk/2005/03/iso8601.html
 # Note: This regex ensures that all ISO8601 timezone formats are accepted - but, due to legacy support for other timestrings, not all incorrect formats can be rejected.

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -215,7 +215,7 @@ def date2num(dates,units,calendar='standard'):
             return cdftime.date2num(dates)
 
 
-def num2date(times,units,calendar='standard',only_use_cftime_datetimes=False):
+def num2date(times,units,calendar='standard',only_use_cftime_datetimes=True):
     """num2date(times,units,calendar='standard')
 
     Return datetime objects given numeric time values. The units
@@ -238,9 +238,9 @@ def num2date(times,units,calendar='standard',only_use_cftime_datetimes=False):
     'noleap', '365_day', '360_day', 'julian', 'all_leap', '366_day'`.
     Default is `'standard'`, which is a mixed Julian/Gregorian calendar.
 
-    **`only_use_cftime_datetimes`**: if False (default), datetime.datetime
+    **`only_use_cftime_datetimes`**: if False, datetime.datetime
     objects are returned from num2date where possible; if True dates which
-    subclass cftime.datetime are returned for all calendars.
+    subclass cftime.datetime are returned for all calendars. Default is True.
 
     returns a datetime instance, or an array of datetime instances with
     approximately 100 microsecond accuracy.
@@ -435,7 +435,7 @@ def JulianDayFromDate(date, calendar='standard'):
     else:
         return jd
 
-def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=False,
+def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=True,
                       return_tuple=False):
     """
 
@@ -690,7 +690,7 @@ it should be noted that udunits treats 0 AD as identical to 1 AD."
     """
 
     def __init__(self, unit_string, calendar='standard',
-                 only_use_cftime_datetimes=False):
+                 only_use_cftime_datetimes=True):
         """
 @param unit_string: a string of the form
 C{'time-units since <time-origin>'} defining the time units.
@@ -723,9 +723,9 @@ are:
  Proleptic Julian calendar, extended to dates after 1582-10-5. A year is a
  leap year if it is divisible by 4.
 
-@keyword only_use_cftime_datetimes: if False (default), datetime.datetime
+@keyword only_use_cftime_datetimes: if False, datetime.datetime
 objects are returned from num2date where possible; if True dates which subclass
-cftime.datetime are returned for all calendars.
+cftime.datetime are returned for all calendars. Default True.
 
 @returns: A class instance which may be used for converting times from netCDF
 units to datetime objects.

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -440,7 +440,8 @@ class cftimeTestCase(unittest.TestCase):
                 err = np.abs(mins1 - mins2)
                 maxerr = max(err,maxerr)
                 assert(err < eps)
-                assert(date1.strftime(dateformat) == date2.strftime(dateformat))
+                diff = abs(date1-date2)
+                assert(diff.microseconds < 100)
             if verbose:
                 print('calendar = %s max abs err (mins) = %s eps = %s' % \
                      (calendar,maxerr,eps))
@@ -456,7 +457,8 @@ class cftimeTestCase(unittest.TestCase):
                 err = np.abs(hrs1 - hrs2)
                 maxerr = max(err,maxerr)
                 assert(err < eps)
-                assert(date1.strftime(dateformat) == date2.strftime(dateformat))
+                diff = abs(date1-date2)
+                assert(diff.microseconds < 100)
             if verbose:
                 print('calendar = %s max abs err (hours) = %s eps = %s' % \
                      (calendar,maxerr,eps))
@@ -472,7 +474,8 @@ class cftimeTestCase(unittest.TestCase):
                 err = np.abs(days1 - days2)
                 maxerr = max(err,maxerr)
                 assert(err < eps)
-                assert(date1.strftime(dateformat) == date2.strftime(dateformat))
+                diff = abs(date1-date2)
+                assert(diff.microseconds < 100)
             if verbose:
                 print('calendar = %s max abs err (days) = %s eps = %s' % \
                      (calendar,maxerr,eps))
@@ -895,8 +898,9 @@ class TestDate2index(unittest.TestCase):
                  datetime(1995, 11, 25, 18, 7, 59, 999999)]
         times2 = date2num(dates, units)
         dates2 = num2date(times2, units)
-        for date, date2 in zip(dates, dates2):
-            assert_equal(date, date2)
+        datediff = abs(dates-dates2)
+        for diff in datediff:
+            assert(diff.microseconds < 100) # tolerance of 100 ms
 
     def test_issue444(self):
         # make sure integer overflow not causing error in


### PR DESCRIPTION
to avoid surprising results, such as discussed in issue #134 