### PR TITLE
format microseconds correctly, make sure num2date gives same answer for scalars and arrays

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,9 @@
+version 1.1.1 (not yet released)
+=====================================
+
+ * fix microsecond formatting issue, ensure identical results
+   computed for arrays and scales (issue #143, PR #146).
+
 version 1.1.0 (release tag v1.1.0rel)
 =====================================
 

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -539,9 +539,10 @@ def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=True,
             year[i],month[i],day[i],dayofwk[i],dayofyr[i] = _IntJulianDayToDate(ijd,calendar)
 
         if calendar in ['standard', 'gregorian']:
-            ind_before = np.where(julian < 2299160.5)[0]
+            ind_before = np.where(julian < 2299160.5)
+            ind_before = np.asarray(ind_before).any()
         else:
-            ind_before = None
+            ind_before = False
 
         # compute hour, minute, second, microsecond, convert to int32
         hour = np.clip((F * 24.).astype(np.int64), 0, 23)
@@ -572,8 +573,8 @@ def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=True,
     indxms = microsecond > 1000000-ms_eps
     if indxms.any():
         julian[indxms] = julian[indxms] + 2*ms_eps[indxms]/86400000000.
-        year,month,day,hour,minute,second,microsecond2,dayofyr,dayofwk,ind_before =\
-        getdateinfo(julian)
+        year[indxms],month[indxms],day[indxms],hour[indxms],minute[indxms],second[indxms],microsecond2,dayofyr[indxms],dayofwk[indxms],ind_before2 =\
+        getdateinfo(julian[indxms])
         microsecond[indxms] = 0
 
     # check if input was scalar and change return accordingly
@@ -599,7 +600,7 @@ def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=True,
         # return a 'real' datetime instance if calendar is proleptic
         # Gregorian or Gregorian and all dates are after the
         # Julian/Gregorian transition
-        if len(ind_before) == 0 and not only_use_cftime_datetimes:
+        if ind_before and not only_use_cftime_datetimes:
             is_real_datetime = True
             datetime_type = real_datetime
         else:

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -569,12 +569,23 @@ def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=True,
     ms_eps = np.atleast_1d(np.array(np.finfo(np.float64).eps,np.longdouble))
     ms_eps = 86400000000.*np.maximum(ms_eps*julian, ms_eps)
     microsecond = np.where(microsecond < ms_eps, 0, microsecond)
-    indxms = microsecond > 1000000-ms_eps
-    if indxms.any():
-        julian[indxms] = julian[indxms] + 2*ms_eps[indxms]/86400000000.
-        year,month,day,hour,minute,second,microsecond,dayofyr,dayofwk,ind_before =\
-        getdateinfo(julian)
-        microsecond[indxms] = 0
+    if microsecond.ndim: # array
+        if calendar in ['standard', 'gregorian']:
+            ind_before = np.zeros(microsecond.size,dtype=np.bool)
+        for i in range(len(microsecond)):
+            if microsecond[i] > 1000000-ms_eps[i]:
+               julian[i] += 2*ms_eps[i]/86400000000.
+               year[i],month[i],day[i],hour[i],minute[i],second[i],microsecond[i],dayofyr[i],dayofwk[i],ind =\
+               getdateinfo(julian[i])
+               if calendar in ['standard', 'gregorian']:
+                   ind_before[i] = ind
+               microsecond[i] = 0
+    else: # scalar
+        if microsecond > 1000000-ms_eps:
+            julian += 2*ms_eps[indxms]/86400000000.
+            year,month,day,hour,minute,second,microsecond,dayofyr,dayofwk,ind_before =\
+            getdateinfo(julian)
+            microsecond = 0
 
     # check if input was scalar and change return accordingly
     isscalar = False
@@ -1327,7 +1338,7 @@ Gregorial calendar.
     def __str__(self):
         second = '{:02d}'.format(self.second)
         if self.microsecond:
-            second += '.{}'.format(self.microsecond)
+            second += '.{:06d}'.format(self.microsecond)
 
         return "{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{}".format(
             self.year, self.month, self.day, self.hour, self.minute, second)

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -571,10 +571,10 @@ def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=True,
     microsecond = np.where(microsecond < ms_eps, 0, microsecond)
     indxms = microsecond > 1000000-ms_eps
     if indxms.any():
-         julian[indxms] = julian[indxms] + 2*ms_eps[indxms]/86400000000.
-         year,month,day,hour,minute,second,microsecond2,dayofyr,dayofwk,ind_before =\
-         getdateinfo(julian)
-         microsecond[indxms] = 0
+        julian[indxms] = julian[indxms] + 2*ms_eps[indxms]/86400000000.
+        year,month,day,hour,minute,second,microsecond2,dayofyr,dayofwk,ind_before =\
+        getdateinfo(julian)
+        microsecond[indxms] = 0
 
     # check if input was scalar and change return accordingly
     isscalar = False

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -52,7 +52,7 @@ cdef int32_t* days_per_month_array = [
 _rop_lookup = {Py_LT: '__gt__', Py_LE: '__ge__', Py_EQ: '__eq__',
                Py_GT: '__lt__', Py_GE: '__le__', Py_NE: '__ne__'}
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 # Adapted from http://delete.me.uk/2005/03/iso8601.html
 # Note: This regex ensures that all ISO8601 timezone formats are accepted - but, due to legacy support for other timestrings, not all incorrect formats can be rejected.

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -582,7 +582,7 @@ def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=True,
                microsecond[i] = 0
     else: # scalar
         if microsecond > 1000000-ms_eps:
-            julian += 2*ms_eps[indxms]/86400000000.
+            julian += 2*ms_eps/86400000000.
             year,month,day,hour,minute,second,microsecond,dayofyr,dayofwk,ind_before =\
             getdateinfo(julian)
             microsecond = 0

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -569,23 +569,12 @@ def DateFromJulianDay(JD, calendar='standard', only_use_cftime_datetimes=True,
     ms_eps = np.atleast_1d(np.array(np.finfo(np.float64).eps,np.longdouble))
     ms_eps = 86400000000.*np.maximum(ms_eps*julian, ms_eps)
     microsecond = np.where(microsecond < ms_eps, 0, microsecond)
-    if microsecond.ndim: # array
-        if calendar in ['standard', 'gregorian']:
-            ind_before = np.zeros(microsecond.size,dtype=np.bool)
-        for i in range(len(microsecond)):
-            if microsecond[i] > 1000000-ms_eps[i]:
-               julian[i] += 2*ms_eps[i]/86400000000.
-               year[i],month[i],day[i],hour[i],minute[i],second[i],microsecond[i],dayofyr[i],dayofwk[i],ind =\
-               getdateinfo(julian[i])
-               if calendar in ['standard', 'gregorian']:
-                   ind_before[i] = ind
-               microsecond[i] = 0
-    else: # scalar
-        if microsecond > 1000000-ms_eps:
-            julian += 2*ms_eps/86400000000.
-            year,month,day,hour,minute,second,microsecond,dayofyr,dayofwk,ind_before =\
-            getdateinfo(julian)
-            microsecond = 0
+    indxms = microsecond > 1000000-ms_eps
+    if indxms.any():
+         julian[indxms] = julian[indxms] + 2*ms_eps[indxms]/86400000000.
+         year,month,day,hour,minute,second,microsecond2,dayofyr,dayofwk,ind_before =\
+         getdateinfo(julian)
+         microsecond[indxms] = 0
 
     # check if input was scalar and change return accordingly
     isscalar = False

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -729,6 +729,17 @@ class cftimeTestCase(unittest.TestCase):
         d = datetime.strptime('2018-01-23 09:27:10.950000',"%Y-%m-%d %H:%M:%S.%f")
         units = 'seconds since 2018-01-23 09:31:42.94'
         assert(cftime.date2num(d, units) == -271.99)
+        # issue 143 - same answer for arrays vs scalars.
+        units = 'seconds since 1970-01-01 00:00:00'
+        times_in = [1261440000.0, 1261440001.0, 1261440002.0, 1261440003.0,
+                    1261440004.0, 1261440005.0]
+        times_out1 = cftime.num2date(times_in, units)
+        times_out2 = []
+        for time_in in times_in:
+            times_out2.append(cftime.num2date(time_in, units))
+        dates1 = [str(d) for d in times_out1]
+        dates2 = [str(d) for d in times_out2]
+        assert(dates1 == dates2)
 
 class TestDate2index(unittest.TestCase):
 
@@ -1517,7 +1528,6 @@ def test_daysinmonth_leap(date_type, month, days_per_month_leap_year):
 def test_replace_dayofyr_or_dayofwk_error(date_type, argument):
     with pytest.raises(ValueError):
         date_type(1, 1, 1).replace(**{argument: 3})
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -740,6 +740,9 @@ class cftimeTestCase(unittest.TestCase):
         dates1 = [str(d) for d in times_out1]
         dates2 = [str(d) for d in times_out2]
         assert(dates1 == dates2)
+        # issue #143 formatting of microseconds
+        d = cftime.num2date(1261440000.000099,units)
+        assert(str(d) == '2009-12-22 00:00:00.000099')
 
 class TestDate2index(unittest.TestCase):
 

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -741,8 +741,8 @@ class cftimeTestCase(unittest.TestCase):
         dates2 = [str(d) for d in times_out2]
         assert(dates1 == dates2)
         # issue #143 formatting of microseconds
-        d = cftime.num2date(1261440000.000099,units)
-        assert(str(d) == '2009-12-22 00:00:00.000099')
+        d = cftime.num2date(1261440000.000999,units)
+        assert(str(d) == '2009-12-22 00:00:00.000999')
 
 class TestDate2index(unittest.TestCase):
 

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -742,7 +742,8 @@ class cftimeTestCase(unittest.TestCase):
         assert(dates1 == dates2)
         # issue #143 formatting of microseconds
         d = cftime.num2date(1261440000.015625,units)
-        assert(str(d) == '2009-12-22 00:00:00.015625')
+        # on windows only 100 ms precision
+        assert(str(d)[0:24] == '2009-12-22 00:00:00.0156')
 
 class TestDate2index(unittest.TestCase):
 

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -741,8 +741,8 @@ class cftimeTestCase(unittest.TestCase):
         dates2 = [str(d) for d in times_out2]
         assert(dates1 == dates2)
         # issue #143 formatting of microseconds
-        d = cftime.num2date(1261440000.000999,units)
-        assert(str(d) == '2009-12-22 00:00:00.000999')
+        d = cftime.num2date(1261440000.015625,units)
+        assert(str(d) == '2009-12-22 00:00:00.015625')
 
 class TestDate2index(unittest.TestCase):
 


### PR DESCRIPTION
addresses issue #143