### PR TITLE
add tarball checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 *.egg-info
 __pycache__
 .pytest_cache/
+dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,19 @@ sudo: false # use container based build
 notifications:
   email: false
 
-env:
-  - PYTHON_VERSION=2.7
-  - PYTHON_VERSION=3.7
-  - PYTHON_VERSION=3.8
-
 matrix:
+  fast_finish: true
   include:
-    - env: PYTHON_VERSION=3.7 BUILD_DOCS="true"
-    - env: PYTHON_VERSION=3.8 TARBALL="true"
+    - name: "python-2.7"
+      env: PY=2.7
+    - name: "python-3.7"
+      env: PY=3.7
+    - name: "python-3.8"
+      env: PY=3.8
+    - name: "tarball"
+      env: PY=3
+    - name: "docs"
+      env: PY=3
 
 before_install:
   # Build the conda testing environment.
@@ -26,11 +30,8 @@ before_install:
     conda update conda --yes --all;
     conda config --add channels conda-forge --force;
     export ENV_NAME="test-environment";
-    conda create --yes -n ${ENV_NAME} python=${PYTHON_VERSION} --file requirements.txt --file requirements-dev.txt;
+    conda create --yes -n ${ENV_NAME} python=${PY} --file requirements.txt --file requirements-dev.txt;
     source activate ${ENV_NAME};
-    if [[ "${BUILD_DOCS}" == "true" ]]; then
-      conda install -qy sphinx;
-    fi;
 
   # Log the conda environment and package details.
   - conda list -n ${ENV_NAME}
@@ -43,17 +44,19 @@ install:
   - CYTHON_COVERAGE=1 pip install -e .
 
 script:
-  - if [[ "${BUILD_DOCS}" == "true" ]]; then
-      pushd docs && make html linkcheck O=-W && popd;
-    else
-      pytest;
+  - if [[ $TRAVIS_JOB_NAME == python-* ]]; then
+      pytest ;
     fi
 
-  - if [[ "${TARBALL}" == "true" ]]; then
-      python setup.py --version ;
-      pip wheel . -w dist --no-deps ;
-      check-manifest --verbose ;
-      twine check dist/* ;
+  - if [[ $TRAVIS_JOB_NAME == 'docs' ]]; then
+      pushd docs && make html linkcheck O=-W && popd;
+    fi
+
+  - if [[ $TRAVIS_JOB_NAME == 'tarball' ]]; then
+     python setup.py --version ;
+     pip wheel . -w dist --no-deps ;
+     check-manifest --verbose ;
+     twine check dist/* ;
     fi
 
 after_success:
@@ -61,10 +64,11 @@ after_success:
 
 before_deploy:
   # Remove unused, unminified javascript from sphinx
-  - if [[ "${BUILD_DOCS}" == "true" ]]; then
-      rm -f docs/build/html/_static/jquery-*.js;
-      rm -f docs/build/html/_static/underscore-*.js;
-      rm -f docs/build/html/.buildinfo;
+  - |
+    if [[ $TRAVIS_JOB_NAME == 'docs' ]]; then
+      rm -f docs/build/html/_static/jquery-*.js
+      rm -f docs/build/html/_static/underscore-*.js
+      rm -f docs/build/html/.buildinfo
     fi
 
 deploy:
@@ -73,4 +77,4 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-      condition: '${PYTHON_VERSION} == 3.7 && ${BUILD_DOCS} == "true"'
+      condition: '$TRAVIS_JOB_NAME == "tarball"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,12 @@ before_install:
 install:
   # Install cftime.
   - echo "Installing cftime..."
-  - CYTHON_COVERAGE=1 pip install -e .
+  - CYTHON_COVERAGE=1 pip install -e . --no-deps --force-reinstall
 
 script:
   - if [[ $TRAVIS_JOB_NAME == python-* ]]; then
-      pytest ;
+      cp -r tests/ /tmp ;
+      pushd /tmp && pytest && popd ;
     fi
 
   - if [[ $TRAVIS_JOB_NAME == 'docs' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 matrix:
   include:
     - env: PYTHON_VERSION=3.7 BUILD_DOCS="true"
+    - env: PYTHON_VERSION=3.8 TARBALL="true"
 
 before_install:
   # Build the conda testing environment.
@@ -46,6 +47,13 @@ script:
       pushd docs && make html linkcheck O=-W && popd;
     else
       pytest;
+    fi
+
+  - if [[ "${TARBALL}" == "true" ]]; then
+      python setup.py --version ;
+      pip wheel . -w dist --no-deps ;
+      check-manifest --verbose ;
+      twine check dist/* ;
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
 
 script:
   - if [[ $TRAVIS_JOB_NAME == python-* ]]; then
-      cp -r tests/ /tmp ;
+      cp -r test/ /tmp ;
       pushd /tmp && pytest && popd ;
     fi
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.txt
+include Changelog
 include README.md
 include COPYING
 include pyproject.toml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,8 @@
+check-manifest
 coverage
 coveralls
 cython
 pytest
 pytest-cov
+twine
+wheel

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,6 @@ coveralls
 cython
 pytest
 pytest-cov
+sphinx
 twine
 wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ ignore =
     *.yml
     .coveragerc
     .gitignore
+    README.release
     ci
     ci/*
     docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,15 @@ addopts =
     --cov=cftime
     --cov-report term-missing
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
+
+[check-manifest]
+ignore =
+    *.yml
+    .coveragerc
+    .gitignore
+    ci
+    ci/*
+    docs
+    docs/*
+    test
+    test/*


### PR DESCRIPTION
@jswhit when I ran this locally I got:

```
> check-manifest --verbose
listing source files under version control: 12 files and directories
building an sdist: cftime-1.1.1.2.tar.gz: 10 files and directories
copying source files to a temporary directory
building a clean sdist: cftime-1.1.1.2.tar.gz: 10 files and directories
lists of files in version control and sdist do not match!
missing from sdist:
  Changelog
  README.release
suggested MANIFEST.in rules:
  include *.release
  include Changelog
```

Do you want to add or skip those? I believe that at least `Changelog` should be there.