### PR TITLE
Make cftime.datetime - cftime.datetime -> timedelta microsecond-exact

### DIFF
--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -1280,7 +1280,6 @@ _converters = {}
 for calendar in _calendars:
     _converters[calendar] = utime("seconds since 1-1-1", calendar)
 
-
 @cython.embedsignature(True)
 cdef class datetime(object):
     """

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -1280,6 +1280,7 @@ _converters = {}
 for calendar in _calendars:
     _converters[calendar] = utime("seconds since 1-1-1", calendar)
 
+
 @cython.embedsignature(True)
 cdef class datetime(object):
     """
@@ -1517,8 +1518,14 @@ Gregorial calendar.
                     raise ValueError("cannot compute the time difference between dates with different calendars")
                 if dt.calendar == "":
                     raise ValueError("cannot compute the time difference between dates that are not calendar-aware")
-                converter = _converters[dt.calendar]
-                return timedelta(seconds=converter.date2num(dt) - converter.date2num(other))
+                ordinal_self = _IntJulianDayFromDate(dt.year, dt.month, dt.day, dt.calendar)
+                ordinal_other = _IntJulianDayFromDate(other.year, other.month, other.day, other.calendar)
+                days = ordinal_self - ordinal_other
+                seconds_self = dt.second + 60 * dt.minute + 3600 * dt.hour
+                seconds_other = other.second + 60 * other.minute + 3600 * other.hour
+                seconds = seconds_self - seconds_other
+                microseconds = dt.microsecond - other.microsecond
+                return timedelta(days, seconds, microseconds)
             elif isinstance(other, datetime_python):
                 # datetime - real_datetime
                 if not dt.datetime_compatible:

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1736,12 +1736,12 @@ def test_num2date_int_only_use_python_datetimes(calendar, shape, dtype):
     if calendar not in _STANDARD_CALENDARS:
         with pytest.raises(ValueError):
             num2date_int(numeric_times, units=units, calendar=calendar,
-                         only_use_python_datetimes=True,
-                         only_use_cftime_datetimes=False)
+                           only_use_python_datetimes=True,
+                           only_use_cftime_datetimes=False)
     else:
         result = num2date_int(numeric_times, units=units, calendar=calendar,
-                              only_use_python_datetimes=True,
-                              only_use_cftime_datetimes=False)
+                                only_use_python_datetimes=True,
+                                only_use_cftime_datetimes=False)
         np.testing.assert_equal(result, expected)
 
 
@@ -1758,8 +1758,8 @@ def test_num2date_int_use_pydatetime_if_possible(calendar, shape, dtype):
     numeric_times = np.array([1, 2, 3, 4]).reshape(shape).astype(dtype)
     units = "days since 2000-01-01"
     result = num2date_int(numeric_times, units=units, calendar=calendar,
-                          only_use_python_datetimes=False,
-                          only_use_cftime_datetimes=False)
+                            only_use_python_datetimes=False,
+                            only_use_cftime_datetimes=False)
     np.testing.assert_equal(result, expected)
 
 

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1583,5 +1583,13 @@ def test_dayofyr_after_timedelta_addition(date_type):
     assert date_after_timedelta_addition.dayofyr == 3
 
 
+def test_exact_datetime_difference(date_type):
+    b = date_type(2000, 1, 2, 0, 0, 0, 5)
+    a = date_type(2000, 1, 2)
+    result = b - a
+    expected = timedelta(microseconds=5)
+    assert result == expected
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently subtracting a date from another to produce a timedelta is not microsecond-exact:

```
In [1]: import cftime

In [2]: cftime.DatetimeNoLeap(2000, 1, 2, 0, 0, 0, 5) - cftime.DatetimeNoLeap(2000, 1, 2)
Out[2]: datetime.timedelta(microseconds=8)
```

I think this is actually pretty straightforward to fix using some code that already exists in cftime.  I'm drawing inspiration here from [the way this kind of operation is done in Python's datetime object](https://github.com/python/cpython/blob/a4c09560eaa1e3b9733c7e63d570b6fa7626724c/Lib/datetime.py#L2084-L2097).  As I understand it, we can simply use `_IntJulianDayFromDate` as something essentially equivalent to `datetime.datetime.toordinal`, and everything else should basically be the same.

The test confirms the example above is fixed for all calendars, and all other existing tests of timedelta arithmetic pass.  @jswhit I think this should enable the exact version of `date2num` you described in https://github.com/Unidata/cftime/issues/171#issuecomment-636201592.  I could try to add that here or in another PR.  As you note, it would be awesome to be able to round-trip dates without loss of precision.

xref: #109 (this would make the function described there no longer necessary)