### PR TITLE
add tooordinal method to cftime.datetime

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+since version 1.2.1 release
+===========================
+ * add tooridinal() to cftime.datetime, expose to_calendar_specific_datetime.
+
 version 1.2.1 (release tag v1.2.1rel)
 =====================================
  * num2date uses 'proleptic_gregorian' scheme when basedate is post-Gregorian but date is pre-Gregorian

--- a/cftime/__init__.py
+++ b/cftime/__init__.py
@@ -5,5 +5,5 @@ from ._cftime import DatetimeNoLeap, DatetimeAllLeap, Datetime360Day, DatetimeJu
                          DatetimeGregorian, DatetimeProlepticGregorian
 from ._cftime import microsec_units, millisec_units, \
                          sec_units, hr_units, day_units, min_units
-from ._cftime import num2date, date2num, date2index, num2pydate
+from ._cftime import num2date, date2num, date2index, num2pydate, to_calendar_specific_datetime
 from ._cftime import __version__

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -332,7 +332,13 @@ DATE_TYPES = {
 }
 
 
+@cython.embedsignature(True)
 def to_calendar_specific_datetime(datetime, calendar, use_python_datetime):
+    """
+    convert from one calendar-specific datetime instance to another.
+    If use_python_datetime=True, convert to python datetime (and ignore
+    calendar kwarg).
+    """
     if use_python_datetime:
         date_type = real_datetime
     else:
@@ -1112,7 +1118,7 @@ datetime object."""
                 return self - other._to_real_datetime()
             else:
                 return NotImplemented
-    
+
     def toordinal(self):
         """
         returns integer days since 1-1-1, like python's datetime toordinal.


### PR DESCRIPTION
so matplotlib.dates.ConciseDateFormatter can be used (issue #191)