### PR TITLE
switch default calendar in date2num to None

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -7,9 +7,9 @@ version 1.3.0 (release tag v1.3.0rel)
    The calendar specific sub-classes are now deprecated, but remain for now
    as stubs that just instantiate the base class and override __repr__.
  * update regex in _cpdef _parse_date so reference years with more than four
-   digits can be handled. Allow 'calendar=None' inr cftime.date2num (calendar associated with first
-   input datetime object is used - we may want to change the default from 'standard' to None
-   in a future release).
+   digits can be handled. 
+ * Change default calendar in cftime.date2num from 'standard' to None
+   (calendar associated with first input datetime object is used).
 
 version 1.2.1 (release tag v1.2.1rel)
 =====================================

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -157,7 +157,7 @@ def _can_use_python_datetime(date,calendar):
            (calendar in ['gregorian','standard'] and date > gregorian and date.year <= MAXYEAR))
 
 @cython.embedsignature(True)
-def date2num(dates,units,calendar='standard'):
+def date2num(dates,units,calendar=None):
     """
     Return numeric time values given datetime objects. The units
     of the numeric time values are described by the **units** argument
@@ -167,19 +167,22 @@ def date2num(dates,units,calendar='standard'):
     returned numeric values.
 
     **dates**: A datetime object or a sequence of datetime objects.
-    The datetime objects should not include a time-zone offset.
+    The datetime objects should not include a time-zone offset. They
+    can be either native python datetime instances (which use
+    the proleptic gregorian calendar) or cftime.datetime instances.
 
     **units**: a string of the form **<time units> since <reference time>**
     describing the time units. **<time units>** can be days, hours, minutes,
     seconds, milliseconds or microseconds. **<reference time>** is the time
     origin. **months_since** is allowed *only* for the **360_day** calendar.
 
-    **calendar**: describes the calendar used in the time calculations.
+    **calendar**: describes the calendar to be used in the time calculations.
     All the values currently defined in the
     [CF metadata convention](http://cfconventions.org)
     Valid calendars **'standard', 'gregorian', 'proleptic_gregorian'
     'noleap', '365_day', '360_day', 'julian', 'all_leap', '366_day'**.
-    Default is **'standard'**, which is a mixed Julian/Gregorian calendar.
+    Default is `None` which means the calendar associated with the rist
+    input datetime instance will be used.
 
     returns a numeric time value, or an array of numeric time values
     with approximately 1 microsecond accuracy.

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -771,10 +771,8 @@ class cftimeTestCase(unittest.TestCase):
 # issue #187 - roundtrip near second boundary
         dt1 = datetime(1810, 4, 24, 16, 15, 10)
         units = 'days since -4713-01-01 12:00'
-        dt2 = num2date(date2num(dt1, units), units)
-        # switch to these if default calendar for date2num changed to None
-        #dt2 = num2date(date2num(dt1, units), units, calendar='proleptic_gregorian')
-        #dt2 = num2date(date2num(dt1, units, calendar='standard'), units)
+        dt2 = num2date(date2num(dt1, units), units, calendar='proleptic_gregorian')
+        dt2 = num2date(date2num(dt1, units, calendar='standard'), units)
         assert(dt1 == dt2)
 # issue #189 - leap years calculated incorrectly for negative years in proleptic_gregorian calendar
         dt1 = datetime(2020, 4, 24, 16, 15, 10)
@@ -798,16 +796,13 @@ class cftimeTestCase(unittest.TestCase):
         # if calendar=None, use input date to determine calendar
         jd = cftime.date2num(d,units,calendar=None)
         assert(jd == 2459198.0)
-        # if no calendar specified, default assumed 'standard'
+        # if no calendar specified, use calendar associated with datetime
+        # instance.
         jd = cftime.date2num(d,units)
+        assert(jd == 2459198.0)
+        # use 'standard' calendar
+        jd = cftime.date2num(d,units,calendar='standard')
         assert(jd == 2459185.0)
-        # switch to these if default calendar for date2num switched to None
-        # if no calendar specified, use input date to determine calendar
-        #jd = cftime.date2num(d,units)
-        #assert(jd == 2459198.0)
-        ## use 'standard' calendar
-        #jd = cftime.date2num(d,units,calendar='standard')
-        #assert(jd == 2459185.0)
 
 
 class TestDate2index(unittest.TestCase):


### PR DESCRIPTION
which causes date2num to use the calendar associated with the first input datetime instance (proleptic_gregorian if datetime instance is native python).  `calendar=""` has the same effect as `calendar=None`.