### PR TITLE
closes issue #211

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+version 1.3.1 (not yet released)
+================================
+ * fix for issue #211 (bug in masked array handling in date2num)
+
 version 1.3.0 (release tag v1.3.0rel)
 =====================================
  * zero pad years in strtime (issue #194)

--- a/cftime/_cftime.pyx
+++ b/cftime/_cftime.pyx
@@ -53,7 +53,7 @@ cdef int32_t* days_per_month_array = [
 _rop_lookup = {Py_LT: '__gt__', Py_LE: '__ge__', Py_EQ: '__eq__',
                Py_GT: '__lt__', Py_GE: '__le__', Py_NE: '__ne__'}
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 
 # Adapted from http://delete.me.uk/2005/03/iso8601.html
 # Note: This regex ensures that all ISO8601 timezone formats are accepted - but, due to legacy support for other timestrings, not all incorrect formats can be rejected.
@@ -216,10 +216,7 @@ def date2num(dates,units,calendar=None):
         if all_python_datetimes:
             calendar = 'proleptic_gregorian'
         else:
-            if isscalar:
-                d0 = dates.item()
-            else:
-                d0 = dates.flat[0]
+            d0 = dates.item(0)
             if isinstance(d0,datetime_python):
                 calendar = 'proleptic_gregorian' 
             else:

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -804,6 +804,17 @@ class cftimeTestCase(unittest.TestCase):
         jd = cftime.date2num(d,units,calendar='standard')
         assert(jd == 2459185.0)
 
+        # issue #211
+        # (masked array handling in date2num - AttributeError:
+        # 'cftime._cftime.DatetimeGregorian' object has no attribute 'view')
+        m = np.ma.asarray(
+            [cftime.DatetimeGregorian(2014, 8, 1, 12, 0, 0, 0)]
+            )
+        assert(
+             cftime.date2num(m, units="seconds since 2000-1-1")==[4.602096e+08]
+              )
+
+
 
 class TestDate2index(unittest.TestCase):
 
@@ -1302,19 +1313,19 @@ class DateTime(unittest.TestCase):
         for op, expected in [(operator.gt, '__lt__'), (operator.ge, '__le__'),
                              (operator.eq, '__eq__'), (operator.ne, '__ne__'),
                              (operator.lt, '__gt__'), (operator.le, '__ge__')]:
-            with self.assertRaisesRegexp(NotImplementedError, expected):
+            with self.assertRaisesRegex(NotImplementedError, expected):
                 op(self.date1_365_day, Rich())
 
-            with self.assertRaisesRegexp(NotImplementedError, '__richcmp__'):
+            with self.assertRaisesRegex(NotImplementedError, '__richcmp__'):
                 op(self.date1_365_day, CythonRich())
 
         # Test RHS operand comparison operator processing.
         for op in [operator.gt, operator.ge, operator.eq, operator.ne,
                    operator.lt, operator.le]:
-            with self.assertRaisesRegexp(TypeError, 'cannot compare'):
+            with self.assertRaisesRegex(TypeError, 'cannot compare'):
                 op(Pass(), self.date1_365_day)
 
-            with self.assertRaisesRegexp(TypeError, 'cannot compare'):
+            with self.assertRaisesRegex(TypeError, 'cannot compare'):
                 op(Pass___cmp__(), self.date1_365_day)
 
 


### PR DESCRIPTION
.flat[0] fails on masked arrays containing datetime instances, use item(0) instead.