### PR TITLE
Further improvements to datetime roundtripping

### DIFF
--- a/.github/workflows/miniconda.yml
+++ b/.github/workflows/miniconda.yml
@@ -40,7 +40,9 @@ jobs:
       run: |
         conda create --name TEST python=${{ matrix.python-version }} --file requirements.txt --file requirements-dev.txt
         source activate TEST
-        CYTHON_COVERAGE=1 pip install -v -e  . --no-deps --force-reinstall
+        # enabling coverage slows down the tests dramaticaly
+        #CYTHON_COVERAGE=1 pip install -v -e  . --no-deps --force-reinstall
+        pip install -v -e  . --no-deps --force-reinstall
         conda info --all
         conda list
 

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,5 @@
-version 1.3.2 (release tag v1.3.2rel)
-=====================================
+Unreleased
+==========
 * `cftime.date2num` will now always return an array of integers, if the units
    and times allow.  Previously this would only be true if the units were
    'microseconds' (PR #225).  In other circumstances, as before, `cftime.date2num`

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,10 @@
+version 1.3.2 (release tag v1.3.2rel)
+=====================================
+* `cftime.date2num` will now always return an array of integers, if the units
+   and times allow.  Previously this would only be true if the units were
+   'microseconds' (PR #225).  In other circumstances, as before, `cftime.date2num`
+   will return an array of floats.
+
 version 1.3.1 (release tag v1.3.1rel)
 =====================================
  * fix for issue #211 (PR #212) bug in masked array handling in date2num)

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -237,7 +237,7 @@ def date2num(dates,units,calendar=None):
         raise ValueError("Unsupported time units provided, {!r}.".format(unit))
     if unit in ["months", "month"] and calendar != "360_day":
         raise ValueError("Units of months only valid for 360_day calendar.")
-    factor = UNIT_CONVERSION_FACTORS[unit]
+    unit_timedelta = timedelta(microseconds=UNIT_CONVERSION_FACTORS[unit])
     can_use_python_basedatetime = _can_use_python_datetime(basedate,calendar)
 
     if can_use_python_basedatetime and all_python_datetimes:
@@ -263,13 +263,10 @@ def date2num(dates,units,calendar=None):
             times.append(None)
         else:
             td = date - basedate
-            if factor == 1.0:
-                # units are microseconds, use integer division
-                times.append(td // timedelta(microseconds=1) )
+            if td % unit_timedelta == timedelta(0):
+                times.append(td // unit_timedelta)
             else:
-                #times.append( (td / timedelta(microseconds=1)) / factor )
-                # this appears to be faster.
-                times.append( (td.total_seconds()*1.e6) / factor )
+                times.append(td / unit_timedelta)
         n += 1
     if ismasked: # convert to masked array if input was masked array
         times = np.array(times)

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -264,7 +264,9 @@ def date2num(dates,units,calendar=None):
         else:
             td = date - basedate
             if td % unit_timedelta == timedelta(0):
-                times.append(td // unit_timedelta)
+                # Explicitly cast result to np.int64 for Windows compatibility
+                quotient = np.int64(td // unit_timedelta)
+                times.append(quotient)
             else:
                 times.append(td / unit_timedelta)
         n += 1

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1924,7 +1924,7 @@ def test_date2num_num2date_roundtrip(encoding_units, freq, calendar):
         np.testing.assert_equal(decoded, times)
     else:
         assert encoded.dtype == np.float64
-        tolerance = timedelta(microseconds=1000)
+        tolerance = timedelta(microseconds=2000)
         meets_tolerance = np.abs(decoded - times) <= tolerance
         assert np.all(meets_tolerance)
 


### PR DESCRIPTION
I forget if there was a reason we did not do this before, but this applies an approach I took in xarray (https://github.com/pydata/xarray/pull/4684) to improve the accuracy of roundtripping `np.datetime64[ns]` dates to `cftime.datetime` objects. The changes here would mean that we'd do our absolute best to retain an integer dtype when encoding times through `date2num`.  

I've included a pretty challenging test that passes on my machine; ~~however it may not be a valid test on 32-bit systems.~~  Edit: I updated the PR for what I think should allow things to pass on Windows.