### PR TITLE
reduce duplicated code in calendar-specific subclasses

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,6 @@
+since version 1.4.1
+===================
+ * clean-up deprecated calendar specific subclasses.
 
 version 1.4.1 (release tag v1.4.1.rel)
 ======================================


### PR DESCRIPTION
by moving changes in `__repr__` and `_getstate` to `cftime.datetime`, and checking `self.__class__.__name`