### PR TITLE
cftime.datetime support for __format__

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
 since version 1.4.1
 ===================
  * clean-up deprecated calendar specific subclasses.
+ * added string formatting support to `cftime.datetime` objects
 
 version 1.4.1 (release tag v1.4.1.rel)
 ======================================

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -983,7 +983,7 @@ The default format of the string produced by strftime is controlled by self.form
 
     def __format__(self, format):
         # the string format "{t_obj}".format(t_obj=t_obj)
-        # without a gives an empty string format specifier
+        # without an explicit format gives an empty string (format='')
         # so set this to None to get the default strftime behaviour
         if format == '':
             format = None

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -981,6 +981,14 @@ The default format of the string produced by strftime is controlled by self.form
             format = self.format
         return _strftime(self, format)
 
+    def __format__(self, format):
+        # the string format "{t_obj}".format(t_obj=t_obj)
+        # without a gives an empty string format specifier
+        # so set this to None to get the default strftime behaviour
+        if format == '':
+            format = None
+        return self.strftime(format)
+
     def replace(self, **kwargs):
         """Return datetime with new specified fields."""
         args = {"year": self.year,

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from calendar import c
 
 import copy
 import operator

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from calendar import c
 
 import copy
 import operator
@@ -1589,6 +1590,13 @@ def test_repr():
     expected = "cftime.datetime(2000, 1, 1, 0, 0, 0, 0, calendar='')"
     assert repr(datetimex(2000, 1, 1, calendar=None)) == expected
 
+def test_string_format():
+    dt = cftime.datetime(2000, 1, 1)
+    # check the default formatting is the same as strftime
+    assert dt.strftime() == '{0}'.format(dt)
+    # check a given format string acts like strftime
+    assert dt.strftime('%H%m%d') == '{0:%H%m%d}'.format(dt)
+    assert 'the year is 2000' == 'the year is {dt:%Y}'.format(dt=dt)
 
 def test_dayofyr_after_replace(date_type):
     date = date_type(1, 1, 1)


### PR DESCRIPTION
This PR adds the `__format__` method to cftime datetime objects.  This allows the use of cftime.datetimes inline within format strings.  Such as:

```
dt = cftime.datetime(2020,1,1)
mystring = "the year is {0:%Y}".format(dt) # >>> the year is 2000
```

and with format strings:
```
mystring = f"the year is {dt:%Y}"  # >>> the year is 2000
```

Things brings formatting parity with `datetime.datetime`.  At present, code like the below will fail if cftime objects are returned, or succeed if datetime objects are returned:
```
dt = num2date(**kwargs)
# dt could be a datetime.datetime or cftime.datetime
print(f"the date is {dt:%Y-%m-%d}")  # currently fails if isinstance(a, cftime.datetime)
```
