### PR TITLE
Add support for 'common_year' and 'common_years' units

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,8 @@
+version x.x.x (release tag vx.x.x.rel)
+======================================
+ * added support for "common_year" and "common_years" units for "noleap" 
+   and "365_day" calendars (issue #5, PR #246)
+
 version 1.5.0 (release tag v1.5.0.rel)
 ======================================
  * clean-up deprecated calendar specific subclasses (PR #231).

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -22,6 +22,7 @@ min_units =      ['minute', 'minutes', 'min', 'mins']
 hr_units =       ['hour', 'hours', 'hr', 'hrs', 'h']
 day_units =      ['day', 'days', 'd']
 month_units =    ['month', 'months'] # only allowed for 360_day calendar
+year_units =     ['common_year', 'years'] # only allowed for 365_day and noleap calendars
 _units = microsec_units+millisec_units+sec_units+min_units+hr_units+day_units
 # supported calendars. Includes synonyms ('standard'=='gregorian',
 # '366_day'=='all_leap','365_day'=='noleap')
@@ -93,9 +94,11 @@ def _dateparse(timestr,calendar,has_year_zero=None):
     if has_year_zero is None:
         has_year_zero = _year_zero_defaults(calendar)
     (units, isostring) = _datesplit(timestr)
-    if not ((units in month_units and calendar=='360_day') or units in _units):
+    if not ((units in month_units and calendar=='360_day') or (units in year_units and calendar in {'365_day', 'noleap'}) or units in _units):
         if units in month_units and calendar != '360_day':
             raise ValueError("'months since' units only allowed for '360_day' calendar")
+        if units in year_units and calendar not in {'365_day', 'noleap'}:    
+            raise ValueError("'%s' units only allowed for '365_day' and 'noleap' calendars" % units) 
         else:
             raise ValueError(
             "units must be one of 'seconds', 'minutes', 'hours' or 'days' (or singular version of these), got '%s'" % units)
@@ -320,7 +323,10 @@ UNIT_CONVERSION_FACTORS = {
     "days": 86400 * 1000000,
     "d": 86400 * 1000000,
     "month": 30 * 86400 * 1000000,  # Only allowed for 360_day calendar
-    "months": 30 * 86400 * 1000000
+    "months": 30 * 86400 * 1000000,
+    "common_year": 365 * 86400 * 1000000, # Only allowed for 365_day and no_leap calendars
+    "years": 365 * 86400 * 1000000 # Only allowed for 365_day and no_leap calendars
+    
 }
 
 DATE_TYPES = {

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -22,7 +22,7 @@ min_units =      ['minute', 'minutes', 'min', 'mins']
 hr_units =       ['hour', 'hours', 'hr', 'hrs', 'h']
 day_units =      ['day', 'days', 'd']
 month_units =    ['month', 'months'] # only allowed for 360_day calendar
-year_units =     ['common_year', 'years'] # only allowed for 365_day and noleap calendars
+year_units =     ['common_year', 'common_years'] # only allowed for 365_day and noleap calendars
 _units = microsec_units+millisec_units+sec_units+min_units+hr_units+day_units
 # supported calendars. Includes synonyms ('standard'=='gregorian',
 # '366_day'=='all_leap','365_day'=='noleap')
@@ -325,7 +325,7 @@ UNIT_CONVERSION_FACTORS = {
     "month": 30 * 86400 * 1000000,  # Only allowed for 360_day calendar
     "months": 30 * 86400 * 1000000,
     "common_year": 365 * 86400 * 1000000, # Only allowed for 365_day and no_leap calendars
-    "years": 365 * 86400 * 1000000 # Only allowed for 365_day and no_leap calendars
+    "common_years": 365 * 86400 * 1000000 # Only allowed for 365_day and no_leap calendars
     
 }
 

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1755,7 +1755,7 @@ _MINUTE_UNITS = ["minutes", "minute", "min", "mins"]
 _HOUR_UNITS = ["hours", "hour", "hr", "hrs", "h"]
 _DAY_UNITS = ["day", "days", "d"]
 _MONTH_UNITS = ["month", "months"]
-_YEAR_UNITS = ["years", "common_year"]
+_YEAR_UNITS = ["common_years", "common_year"]
 _DTYPES = [np.dtype("int64"), np.dtype("float64")]
 _STANDARD_CALENDARS = [
     "standard",

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1755,6 +1755,7 @@ _MINUTE_UNITS = ["minutes", "minute", "min", "mins"]
 _HOUR_UNITS = ["hours", "hour", "hr", "hrs", "h"]
 _DAY_UNITS = ["day", "days", "d"]
 _MONTH_UNITS = ["month", "months"]
+_YEAR_UNITS = ["years", "common_year"]
 _DTYPES = [np.dtype("int64"), np.dtype("float64")]
 _STANDARD_CALENDARS = [
     "standard",
@@ -1874,6 +1875,23 @@ def test_num2date_month_units(calendar, unit, shape, dtype):
     units = "{} since 2000-01-01".format(unit)
 
     if calendar != "360_day":
+        with pytest.raises(ValueError):
+            num2date(numeric_times, units=units, calendar=calendar)
+    else:
+        result = num2date(numeric_times, units=units, calendar=calendar)
+        np.testing.assert_equal(result, expected)
+
+@pytest.mark.parametrize("unit", _YEAR_UNITS)
+def test_num2date_year_units(calendar, unit, shape, dtype):
+    date_type = _EXPECTED_DATE_TYPES[calendar]
+    expected = np.array([date_type(2001, 1, 1, 0, 0, 0, 0),
+                         date_type(2002, 1, 1, 0, 0, 0, 0),
+                         date_type(2003, 1, 1, 0, 0, 0, 0),
+                         date_type(2004, 1, 1, 0, 0, 0, 0)]).reshape(shape)
+    numeric_times = np.array([1, 2, 3, 4]).reshape(shape).astype(dtype)
+    units = "{} since 2000-01-01".format(unit)
+
+    if calendar not in {"365_day", "noleap"}:
         with pytest.raises(ValueError):
             num2date(numeric_times, units=units, calendar=calendar)
     else:


### PR DESCRIPTION
This PR is my attempt at fixing #5. As discussed in #5, the only supported calendars for year units are `365_day` and `noleap`. 

```python 
In [1]: import cftime

In [2]: values = [1, 2, 3]

In [3]: units = 'common_year since 0000-01-01 0:0:0'

In [4]: cftime.num2date(values, units, 'noleap')
Out[4]: 
array([cftime.DatetimeNoLeap(1, 1, 1, 0, 0, 0, 0, has_year_zero=True),
       cftime.DatetimeNoLeap(2, 1, 1, 0, 0, 0, 0, has_year_zero=True),
       cftime.DatetimeNoLeap(3, 1, 1, 0, 0, 0, 0, has_year_zero=True)],
      dtype=object)

In [5]: cftime.num2date(values, units, '365_day')
Out[5]: 
array([cftime.DatetimeNoLeap(1, 1, 1, 0, 0, 0, 0, has_year_zero=True),
       cftime.DatetimeNoLeap(2, 1, 1, 0, 0, 0, 0, has_year_zero=True),
       cftime.DatetimeNoLeap(3, 1, 1, 0, 0, 0, 0, has_year_zero=True)],
      dtype=object)
```

Using `common_year` or `years` units with other calendars results in failures as intended:

```python
n [6]: cftime.num2date(values, units, 'standard')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-6-5819edfbac07> in <module>
----> 1 cftime.num2date(values, units, 'standard')

~/devel/unidata/cftime/src/cftime/_cftime.pyx in cftime._cftime.num2date()
    488     if has_year_zero is None:
    489         has_year_zero = _year_zero_defaults(calendar)
--> 490     basedate = _dateparse(units,calendar=calendar,has_year_zero=has_year_zero)
    491 
    492     can_use_python_datetime=_can_use_python_datetime(basedate,calendar)

~/devel/unidata/cftime/src/cftime/_cftime.pyx in cftime._cftime._dateparse()
     99             raise ValueError("'months since' units only allowed for '360_day' calendar")
    100         if units in year_units and calendar not in {'365_day', 'noleap'}:
--> 101             raise ValueError("'%s' units only allowed for '365_day' and 'noleap' calendars" % units)
    102         else:
    103             raise ValueError(

ValueError: 'common_year' units only allowed for '365_day' and 'noleap' calendars
```

@kmpaul, let me know if this PR fully addresses #5. 
