### PR TITLE
address issue #248

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,7 @@ version 1.5.1 (not yet released)
  * check consistency of year arg and has_year_zero kwarg in cftime.datetime
    (issue #248).  Also assume if has_year_zero not specified it should be True
    if year=0. Allow replace method to change has_year_zero.
+ * '360_day' was missing from list of 'idealized' calendars.
 
 version 1.5.0 (release tag v1.5.0.rel)
 ======================================

--- a/Changelog
+++ b/Changelog
@@ -3,7 +3,7 @@ version 1.5.1 (not yet released)
  * added support for "common_year" and "common_years" units for "noleap" 
    and "365_day" calendars (issue #5, PR #246)
  * check consistency of year arg and has_year_zero kwarg in cftime.datetime
-   (issue #248).  Also ssume if has_year_zero not specified it should be True
+   (issue #248).  Also assume if has_year_zero not specified it should be True
    if year=0. Allow replace method to change has_year_zero.
 
 version 1.5.0 (release tag v1.5.0.rel)

--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,9 @@ version 1.5.1 (not yet released)
 ======================================
  * added support for "common_year" and "common_years" units for "noleap" 
    and "365_day" calendars (issue #5, PR #246)
+ * check consistency of year arg and has_year_zero kwarg in cftime.datetime
+   (issue #248).  Also ssume if has_year_zero not specified it should be True
+   if year=0.
 
 version 1.5.0 (release tag v1.5.0.rel)
 ======================================

--- a/Changelog
+++ b/Changelog
@@ -4,7 +4,7 @@ version 1.5.1 (not yet released)
    and "365_day" calendars (issue #5, PR #246)
  * check consistency of year arg and has_year_zero kwarg in cftime.datetime
    (issue #248).  Also ssume if has_year_zero not specified it should be True
-   if year=0.
+   if year=0. Allow replace method to change has_year_zero.
 
 version 1.5.0 (release tag v1.5.0.rel)
 ======================================

--- a/Changelog
+++ b/Changelog
@@ -4,7 +4,9 @@ version 1.5.1 (not yet released)
    and "365_day" calendars (issue #5, PR #246)
  * check consistency of year arg and has_year_zero kwarg in cftime.datetime
    (issue #248).  Also assume if has_year_zero not specified it should be True
-   if year=0. Allow replace method to change has_year_zero.
+   if year=0. Allow replace method to change has_year_zero. Issue UserWarning
+   if year set to zero and calendar default is changed from False to True
+   (so that user is aware the resulting instance will not be CF compliant).
  * '360_day' was missing from list of 'idealized' calendars.
 
 version 1.5.0 (release tag v1.5.0.rel)

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -1016,7 +1016,7 @@ The default format of the string produced by strftime is controlled by self.form
                 # include the year zero (issue #248)
                 # warn if calendar is being set to non-CF calendar
                 msg="year=0 was specified - this date/calendar/year zero convention is not supported by CF"
-                if not _year_zero_defaults(calendar):
+                if calendar is not None and not _year_zero_defaults(calendar):
                     warnings.warn(msg,category=CFWarning)
                 has_year_zero=True
             else:

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -931,6 +931,7 @@ cdef _year_zero_defaults(calendar):
 # factory function without optional kwargs that can be used in datetime.__reduce__
 def _create_datetime(args, kwargs): return datetime(*args, **kwargs)
 # custorm warning for invalid CF dates.
+cfwarnmsg="this date/calendar/year zero convention is not supported by CF"
 class CFWarning(UserWarning):
     pass
 
@@ -1013,20 +1014,23 @@ The default format of the string produced by strftime is controlled by self.form
             if year == 0:
                 # assume if user sets year to zero, the calendar should
                 # include the year zero (issue #248)
+                # warn if calendar is being set to non-CF calendar
+                msg="year=0 was specified - this date/calendar/year zero convention is not supported by CF"
+                if not _year_zero_defaults(calendar):
+                    warnings.warn(msg,category=CFWarning)
                 has_year_zero=True
             else:
                 has_year_zero = _year_zero_defaults(calendar)
         # raise exception if year zero requested but has_year_zero set
         # to False (issue #248).
-        if year == 0 and not has_year_zero:
+        if year == 0 and has_year_zero==False:
             msg='year zero requested, but has_year_zero=False'
             raise ValueError(msg)
         if not has_year_zero and calendar in _idealized_calendars:
             warnings.warn('has_year_zero kwarg ignored for idealized calendars (always True)')
         #if (calendar in ['julian','gregorian','standard'] and year <= 0) or\
         #   (calendar == 'proleptic_gregorian' and not has_year_zero and year < 1):
-        #    msg="this date/calendar/year zero convention is not supported by CF"
-        #    warnings.warn(msg,category=CFWarning)
+        #    warnings.warn(cfwarnmsg,category=CFWarning)
         self.has_year_zero = has_year_zero
         if calendar == 'gregorian' or calendar == 'standard':
             # dates after 1582-10-15 can be converted to and compared to

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -30,7 +30,7 @@ _units = microsec_units+millisec_units+sec_units+min_units+hr_units+day_units
 # for definitions.
 _calendars = ['standard', 'gregorian', 'proleptic_gregorian',
               'noleap', 'julian', 'all_leap', '365_day', '366_day', '360_day']
-_idealized_calendars= ['all_leap','noleap','366_day','365_day']
+_idealized_calendars= ['all_leap','noleap','366_day','365_day','360_day']
 # Following are number of days per month
 cdef int[12] _dayspermonth      = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 cdef int[12] _dayspermonth_leap = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -1157,7 +1157,6 @@ The default format of the string produced by strftime is controlled by self.form
         for name, value in kwargs.items():
             args[name] = value
 
-
         return self.__class__(**args)
 
     def timetuple(self):

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -908,6 +908,10 @@ class cftimeTestCase(unittest.TestCase):
         assert(d.has_year_zero==False)
         d = d.replace(year=0)
         assert(d.has_year_zero==True)
+        # this should raise a warning, since the default has_year_zero
+        # is changed if year specified as zero. (issue #248, PR #249)
+        self.assertWarns(UserWarning, cftime.datetime, 0, 1, 1,\
+                calendar='standard')
         # check that for idealized calendars has_year_zero is always True
         d=cftime.datetime(0, 1, 1, calendar='360_day')
         assert(d.has_year_zero==True)

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1319,7 +1319,7 @@ class DateTime(unittest.TestCase):
         def invalid_year():
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore",category=cftime.CFWarning)
-                DatetimeGregorian(0, 1, 1) + self.delta
+                DatetimeGregorian(0, 1, 1, has_year_zero=False) + self.delta
 
         def invalid_month():
             DatetimeGregorian(1, 13, 1) + self.delta

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1534,8 +1534,10 @@ def test_zero_year(date_type):
         if date_type in [DatetimeNoLeap, DatetimeAllLeap, Datetime360Day]: 
             date_type(0, 1, 1)
         else:
+            d=date_type(0,1,1) # has_year_zero=True set if year 0 specified
+            assert(d.has_year_zero) # (issue #248) 
             with pytest.raises(ValueError):
-                date_type(0, 1, 1)
+                date_type(0, 1, 1, has_year_zero=False)
 
 
 def test_invalid_month(date_type):

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -900,6 +900,21 @@ class cftimeTestCase(unittest.TestCase):
                     assert(d.toordinal() == jdref)
                     d2 = cftime.datetime.fromordinal(jd,calendar=calendar,has_year_zero=has_year_zero)
                     assert(d2 == d)
+        # issue #248.  Set has_year_zero=True if year zero requested
+        # on instance creation, or by using replace method.
+        d=cftime.datetime(0, 0, 0, calendar=None)
+        assert(d.has_year_zero==True)
+        d=cftime.datetime(1, 0, 0, calendar=None)
+        assert(d.has_year_zero==False)
+        d = d.replace(year=0)
+        assert(d.has_year_zero==True)
+        # check that for idealized calendars has_year_zero is always True
+        d=cftime.datetime(0, 1, 1, calendar='360_day')
+        assert(d.has_year_zero==True)
+        d=cftime.datetime(1, 1, 1, calendar='360_day')
+        assert(d.has_year_zero==True)
+        d = d.replace(year=0)
+        assert(d.has_year_zero==True)
 
 
 class TestDate2index(unittest.TestCase):


### PR DESCRIPTION
This PR changes the behavior of cftime.datetime initialization.  Previously, specifying year=0 without the has_year_zero kwarg will raise an exception if the default  for that calendar is has_year_zero=False.  With this change specifying year=0 without a has_year_zero kwarg will cause has_year_zero to be set to True. 

The assumption here is that if the user is asking for an instance for year=0, they implicitly want the version of the calendar that includes year zero.

@spencerkclark would appreciate it if you would take a look at this and make sure it doesn't break xarray