### PR TITLE
test: fix numpy warning with np.float

### DIFF
--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -921,7 +921,7 @@ class TestDate2index(unittest.TestCase):
             self.calendar = calendar
             t0 = date2num(start, units, calendar)
             self._data = (t0 + np.arange(n) * step).astype('float')
-            self.dtype = np.float
+            self.dtype = float
 
         def __getitem__(self, item):
             return self._data[item]


### PR DESCRIPTION
>DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`.
>Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

The warning also says:

>Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.

It did not seem to me that was the case, so I’ve replaced with `float` directly.