### PR TITLE
Ensure subclass type is properly roundtripped during pickling

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,8 @@ version 1.5.1 (not yet released)
 ======================================
  * added support for "common_year" and "common_years" units for "noleap" 
    and "365_day" calendars (issue #5, PR #246)
+ * fixed a bug that led to subclasses losing their type identity upon
+   pickling (issue #251, PR #252).
 
 version 1.5.0 (release tag v1.5.0.rel)
 ======================================

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -929,7 +929,7 @@ cdef _year_zero_defaults(calendar):
        return False
 
 # factory function without optional kwargs that can be used in datetime.__reduce__
-def _create_datetime(args, kwargs): return datetime(*args, **kwargs)
+def _create_datetime(date_type, args, kwargs): return date_type(*args, **kwargs)
 # custorm warning for invalid CF dates.
 class CFWarning(UserWarning):
     pass
@@ -1255,7 +1255,8 @@ The default format of the string produced by strftime is controlled by self.form
     def __reduce__(self):
         """special method that allows instance to be pickled"""
         args, kwargs = self._getstate()
-        return (_create_datetime, (args, kwargs))
+        date_type = type(self)
+        return (_create_datetime, (date_type, args, kwargs))
 
     cdef _add_timedelta(self, other):
         return NotImplemented

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1309,6 +1309,11 @@ class DateTime(unittest.TestCase):
         self.assertEqual(date, deserialized)
         self.assertEqual(type(date), type(deserialized))
 
+        date = datetimex(1, 2, 3, 4, 5, 6, 7, calendar="360_day")
+        deserialized = pickle.loads(pickle.dumps(date))
+        self.assertEqual(date, deserialized)
+        self.assertEqual(type(date), type(deserialized))
+        
     def test_misc(self):
         "Miscellaneous tests."
         # make sure repr succeeds

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1305,7 +1305,9 @@ class DateTime(unittest.TestCase):
         import pickle
 
         date = Datetime360Day(year=1, month=2, day=3, hour=4, minute=5, second=6, microsecond=7)
-        self.assertEqual(date, pickle.loads(pickle.dumps(date)))
+        deserialized = pickle.loads(pickle.dumps(date))
+        self.assertEqual(date, deserialized)
+        self.assertEqual(type(date), type(deserialized))
 
     def test_misc(self):
         "Miscellaneous tests."


### PR DESCRIPTION
This PR addresses the issue in #251.  It appears there was an existing test of pickle roundtripping, but it only checked that the result was equal to the input.  It seems testing for equality does not check equality of types.  

cc: @aidanheerdegen 