### PR TITLE
address deprecation of calendar='gregorian' in CF v1.9 (issue #256)

### DIFF
--- a/.github/workflows/miniconda.yml
+++ b/.github/workflows/miniconda.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9"]
+        python-version: [ "3.7", "3.8", "3.9", "3.10"]
         os: [windows-latest, ubuntu-latest, macos-latest]
         platform: [x64, x32]
 #  debug on a single os/platform/python version

--- a/.github/workflows/miniconda.yml
+++ b/.github/workflows/miniconda.yml
@@ -64,7 +64,7 @@ jobs:
 #       coveralls --service=github-actions
 
     - name: Tarball
-      if: startsWith(matrix.os,'ubuntu')
+      if: startsWith(matrix.os,'ubuntu') && matrix.python-version == '3.9'
       shell: bash -l {0}
       run: |
         source activate TEST

--- a/.github/workflows/miniconda.yml
+++ b/.github/workflows/miniconda.yml
@@ -74,7 +74,7 @@ jobs:
         twine check dist/* ;
  
     - name: Docs
-      if: startsWith(matrix.os,'ubuntu')
+      if: startsWith(matrix.os,'ubuntu') && matrix.python-version == '3.9'
       shell: bash -l {0}
       run: |
         source activate TEST

--- a/Changelog
+++ b/Changelog
@@ -1,7 +1,6 @@
 version 1.5.2 (not yet released)
 ================================
  * silently change calendar='gregorian' to 'standard' internally, 
-   and add DatetimeStandard as a replacement for DatetimeGregorian
    since 'gregorian' deprecated in CF v1.9 (issue #256).
    
 version 1.5.1.1

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+since version 1.5.1.1
+=====================
+ * raise DeprecationWarning for calendar='gregorian', add DatetimeStandard as a replacement for DatetimeGregorian.
+   
 version 1.5.1.1
 ===============
  * no code changes, just new binary wheels for python 3.10.

--- a/Changelog
+++ b/Changelog
@@ -1,7 +1,8 @@
 version 1.5.2 (not yet released)
 ================================
- * raise DeprecationWarning for calendar='gregorian', add DatetimeStandard as a replacement for DatetimeGregorian
-   (issue #256)..
+ * silently change calendar='gregorian' to 'standard' internally, 
+   and add DatetimeStandard as a replacement for DatetimeGregorian
+   since 'gregorian' deprecated in CF v1.9 (issue #256).
    
 version 1.5.1.1
 ===============

--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
-since version 1.5.1.1
-=====================
- * raise DeprecationWarning for calendar='gregorian', add DatetimeStandard as a replacement for DatetimeGregorian.
+version 1.5.2 (not yet released)
+================================
+ * raise DeprecationWarning for calendar='gregorian', add DatetimeStandard as a replacement for DatetimeGregorian
+   (issue #256)..
    
 version 1.5.1.1
 ===============

--- a/src/cftime/__init__.py
+++ b/src/cftime/__init__.py
@@ -7,5 +7,5 @@ from ._cftime import (microsec_units, millisec_units,
 from ._cftime import __version__, CFWarning
 # these will be removed in a future release
 from ._cftime import (DatetimeNoLeap, DatetimeAllLeap, Datetime360Day,
-                     Datetime360Day, DatetimeJulian, 
+                     Datetime360Day, DatetimeJulian, DatetimeStandard,
                      DatetimeGregorian, DatetimeProlepticGregorian)

--- a/src/cftime/__init__.py
+++ b/src/cftime/__init__.py
@@ -7,5 +7,5 @@ from ._cftime import (microsec_units, millisec_units,
 from ._cftime import __version__, CFWarning
 # these will be removed in a future release
 from ._cftime import (DatetimeNoLeap, DatetimeAllLeap, Datetime360Day,
-                     Datetime360Day, DatetimeJulian, DatetimeStandard,
+                     Datetime360Day, DatetimeJulian, 
                      DatetimeGregorian, DatetimeProlepticGregorian)

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -28,7 +28,7 @@ _units = microsec_units+millisec_units+sec_units+min_units+hr_units+day_units
 # '366_day'=='all_leap','365_day'=='noleap')
 # see http://cfconventions.org/cf-conventions/cf-conventions#calendar
 # for definitions.
-_calendars = ['gregorian', 'standard', 'proleptic_gregorian',
+_calendars = ['standard', 'gregorian', 'proleptic_gregorian',
               'noleap', 'julian', 'all_leap', '365_day', '366_day', '360_day']
 _idealized_calendars= ['all_leap','noleap','366_day','365_day','360_day']
 # Following are number of days per month

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -1396,6 +1396,8 @@ The default format of the string produced by strftime is controlled by self.form
             return DatetimeJulian(*add_timedelta(dt, delta, is_leap_julian, False, has_year_zero),has_year_zero=has_year_zero)
         elif calendar == 'standard':
             #return dt.__class__(*add_timedelta(dt, delta, is_leap_gregorian, True, has_year_zero),calendar=calendar,has_year_zero=has_year_zero)
+            # should return DatetimeStandard, but use DatetimeGregorian
+            # for backwards compatibility.
             return DatetimeGregorian(*add_timedelta(dt, delta, is_leap_gregorian, True, has_year_zero),has_year_zero=has_year_zero)
         elif calendar == 'proleptic_gregorian':
             #return dt.__class__(*add_timedelta(dt, delta, is_leap_proleptic_gregorian, False, has_year_zero),calendar=calendar,has_year_zero=has_year_zero)
@@ -1455,6 +1457,8 @@ datetime object."""
                 elif self.calendar == 'standard':
                     #return self.__class__(*add_timedelta(self, -other, 
                     #     is_leap_gregorian, True, has_year_zero),calendar=self.calendar,has_year_zero=self.has_year_zero)
+                    # should return DatetimeStandard, but use DatetimeGregorian
+                    # for backwards compatibility.
                     return DatetimeGregorian(*add_timedelta(self, -other, is_leap_gregorian, True, has_year_zero),has_year_zero=self.has_year_zero)
                 elif self.calendar == 'proleptic_gregorian':
                     #return self.__class__(*add_timedelta(self, -other,

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -28,7 +28,7 @@ _units = microsec_units+millisec_units+sec_units+min_units+hr_units+day_units
 # '366_day'=='all_leap','365_day'=='noleap')
 # see http://cfconventions.org/cf-conventions/cf-conventions#calendar
 # for definitions.
-_calendars = ['standard', 'gregorian', 'proleptic_gregorian',
+_calendars = ['gregorian', 'standard', 'proleptic_gregorian',
               'noleap', 'julian', 'all_leap', '365_day', '366_day', '360_day']
 _idealized_calendars= ['all_leap','noleap','366_day','365_day','360_day']
 # Following are number of days per month
@@ -1050,9 +1050,6 @@ The default format of the string produced by strftime is controlled by self.form
         if calendar == 'gregorian' or calendar == 'standard':
             # dates after 1582-10-15 can be converted to and compared to
             # proleptic Gregorian dates
-            #if calendar == 'gregorian':
-            #    msg="calendar name 'gregorian' deprecated in CF v1.9 (use 'standard' instead)"
-            #    warnings.warn(msg,category=DeprecationWarning)
             self.calendar = 'standard'
             if self.to_tuple() >= (1582, 10, 15, 0, 0, 0, 0):
                 self.datetime_compatible = True
@@ -1768,8 +1765,6 @@ cdef _check_calendar(calendar):
     calout = calendar
     # remove 'gregorian','noleap','all_leap'
     if calendar == 'gregorian':
-        #msg="calendar name 'gregorian' deprecated in CF v1.9 (use 'standard' instead)"
-        #warnings.warn(msg,category=DeprecationWarning)
         calout = 'standard'
     if calendar == 'noleap':
         calout = '365_day'

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -38,7 +38,7 @@ cdef int[12] _dayspermonth_leap = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 3
 cdef int[13] _cumdayspermonth = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365]
 cdef int[13] _cumdayspermonth_leap = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366]
 
-__version__ = '1.5.1.1'
+__version__ = '1.5.2'
 
 # Adapted from http://delete.me.uk/2005/03/iso8601.html
 # Note: This regex ensures that all ISO8601 timezone formats are accepted - but, due to legacy support for other timestrings, not all incorrect formats can be rejected.

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -336,7 +336,7 @@ UNIT_CONVERSION_FACTORS = {
 
 DATE_TYPES = {
      "proleptic_gregorian": DatetimeProlepticGregorian,
-     "standard": DatetimeStandard,
+     "standard": DatetimeGregorian,
      "noleap": DatetimeNoLeap,
      "365_day": DatetimeNoLeap,
      "all_leap": DatetimeAllLeap,
@@ -1396,8 +1396,6 @@ The default format of the string produced by strftime is controlled by self.form
             return DatetimeJulian(*add_timedelta(dt, delta, is_leap_julian, False, has_year_zero),has_year_zero=has_year_zero)
         elif calendar == 'standard':
             #return dt.__class__(*add_timedelta(dt, delta, is_leap_gregorian, True, has_year_zero),calendar=calendar,has_year_zero=has_year_zero)
-            # should return DatetimeStandard, but use DatetimeGregorian
-            # for backwards compatibility.
             return DatetimeGregorian(*add_timedelta(dt, delta, is_leap_gregorian, True, has_year_zero),has_year_zero=has_year_zero)
         elif calendar == 'proleptic_gregorian':
             #return dt.__class__(*add_timedelta(dt, delta, is_leap_proleptic_gregorian, False, has_year_zero),calendar=calendar,has_year_zero=has_year_zero)
@@ -1457,8 +1455,6 @@ datetime object."""
                 elif self.calendar == 'standard':
                     #return self.__class__(*add_timedelta(self, -other, 
                     #     is_leap_gregorian, True, has_year_zero),calendar=self.calendar,has_year_zero=self.has_year_zero)
-                    # should return DatetimeStandard, but use DatetimeGregorian
-                    # for backwards compatibility.
                     return DatetimeGregorian(*add_timedelta(self, -other, is_leap_gregorian, True, has_year_zero),has_year_zero=self.has_year_zero)
                 elif self.calendar == 'proleptic_gregorian':
                     #return self.__class__(*add_timedelta(self, -other,
@@ -1923,7 +1919,7 @@ but uses the "julian" calendar.
         super().__init__(*args, **kwargs)
 
 @cython.embedsignature(True)
-cdef class DatetimeStandard(datetime):
+cdef class DatetimeGregorian(datetime):
     """
 Phony datetime object which mimics the python datetime object,
 but uses the mixed Julian-Gregorian ("standard") calendar.
@@ -1931,10 +1927,6 @@ but uses the mixed Julian-Gregorian ("standard") calendar.
     def __init__(self, *args, **kwargs):
         kwargs['calendar']='standard'
         super().__init__(*args, **kwargs)
-
-# for backwards compatibility (until 'gregorian' calendar removed)
-cdef class DatetimeGregorian(DatetimeStandard):
-    pass
 
 @cython.embedsignature(True)
 cdef class DatetimeProlepticGregorian(datetime):

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -336,7 +336,7 @@ UNIT_CONVERSION_FACTORS = {
 
 DATE_TYPES = {
      "proleptic_gregorian": DatetimeProlepticGregorian,
-     "standard": DatetimeGregorian,
+     "standard": DatetimeStandard,
      "noleap": DatetimeNoLeap,
      "365_day": DatetimeNoLeap,
      "all_leap": DatetimeAllLeap,
@@ -1050,7 +1050,10 @@ The default format of the string produced by strftime is controlled by self.form
         if calendar == 'gregorian' or calendar == 'standard':
             # dates after 1582-10-15 can be converted to and compared to
             # proleptic Gregorian dates
-            self.calendar = 'gregorian'
+            if calendar == 'gregorian':
+                msg="calendar name 'gregorian' deprecated in CF v1.9 (use 'standard' instead)"
+                warnings.warn(msg,category=DeprecationWarning)
+            self.calendar = 'standard'
             if self.to_tuple() >= (1582, 10, 15, 0, 0, 0, 0):
                 self.datetime_compatible = True
             else:
@@ -1394,9 +1397,9 @@ The default format of the string produced by strftime is controlled by self.form
         elif calendar == 'julian':
             #return dt.__class__(*add_timedelta(dt, delta, is_leap_julian, False, has_year_zero),calendar=calendar,has_year_zero=has_year_zero)
             return DatetimeJulian(*add_timedelta(dt, delta, is_leap_julian, False, has_year_zero),has_year_zero=has_year_zero)
-        elif calendar == 'gregorian':
+        elif calendar == 'standard':
             #return dt.__class__(*add_timedelta(dt, delta, is_leap_gregorian, True, has_year_zero),calendar=calendar,has_year_zero=has_year_zero)
-            return DatetimeGregorian(*add_timedelta(dt, delta, is_leap_gregorian, True, has_year_zero),has_year_zero=has_year_zero)
+            return DatetimeStandard(*add_timedelta(dt, delta, is_leap_gregorian, True, has_year_zero),has_year_zero=has_year_zero)
         elif calendar == 'proleptic_gregorian':
             #return dt.__class__(*add_timedelta(dt, delta, is_leap_proleptic_gregorian, False, has_year_zero),calendar=calendar,has_year_zero=has_year_zero)
             return DatetimeProlepticGregorian(*add_timedelta(dt, delta, is_leap_proleptic_gregorian, False, has_year_zero),has_year_zero=has_year_zero)
@@ -1452,10 +1455,10 @@ datetime object."""
                     #return self.__class__(*add_timedelta(self, -other, 
                     #     is_leap_julian, False, has_year_zero),calendar=self.calendar,has_year_zero=self.has_year_zero)
                     return DatetimeJulian(*add_timedelta(self, -other, is_leap_julian, False, has_year_zero),has_year_zero=self.has_year_zero)
-                elif self.calendar == 'gregorian':
+                elif self.calendar == 'standard':
                     #return self.__class__(*add_timedelta(self, -other, 
                     #     is_leap_gregorian, True, has_year_zero),calendar=self.calendar,has_year_zero=self.has_year_zero)
-                    return DatetimeGregorian(*add_timedelta(self, -other, is_leap_gregorian, True, has_year_zero),has_year_zero=self.has_year_zero)
+                    return DatetimeStandard(*add_timedelta(self, -other, is_leap_gregorian, True, has_year_zero),has_year_zero=self.has_year_zero)
                 elif self.calendar == 'proleptic_gregorian':
                     #return self.__class__(*add_timedelta(self, -other,
                     #    is_leap_proleptic_gregorian, False, has_year_zero),calendar=self.calendar,has_year_zero=self.has_year_zero)
@@ -1764,7 +1767,9 @@ cdef _check_calendar(calendar):
         raise ValueError('unsupported calendar')
     calout = calendar
     # remove 'gregorian','noleap','all_leap'
-    if calendar in 'gregorian':
+    if calendar == 'gregorian':
+        msg="calendar name 'gregorian' deprecated in CF v1.9 (use 'standard' instead)"
+        warnings.warn(msg,category=DeprecationWarning)
         calout = 'standard'
     if calendar == 'noleap':
         calout = '365_day'
@@ -1919,14 +1924,18 @@ but uses the "julian" calendar.
         super().__init__(*args, **kwargs)
 
 @cython.embedsignature(True)
-cdef class DatetimeGregorian(datetime):
+cdef class DatetimeStandard(datetime):
     """
 Phony datetime object which mimics the python datetime object,
-but uses the mixed Julian-Gregorian ("standard", "gregorian") calendar.
+but uses the mixed Julian-Gregorian ("standard") calendar.
     """
     def __init__(self, *args, **kwargs):
-        kwargs['calendar']='gregorian'
+        kwargs['calendar']='standard'
         super().__init__(*args, **kwargs)
+
+# for backwards compatibility (until 'gregorian' calendar removed)
+cdef class DatetimeGregorian(DatetimeStandard):
+    pass
 
 @cython.embedsignature(True)
 cdef class DatetimeProlepticGregorian(datetime):

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -1399,7 +1399,7 @@ The default format of the string produced by strftime is controlled by self.form
             return DatetimeJulian(*add_timedelta(dt, delta, is_leap_julian, False, has_year_zero),has_year_zero=has_year_zero)
         elif calendar == 'standard':
             #return dt.__class__(*add_timedelta(dt, delta, is_leap_gregorian, True, has_year_zero),calendar=calendar,has_year_zero=has_year_zero)
-            return DatetimeStandard(*add_timedelta(dt, delta, is_leap_gregorian, True, has_year_zero),has_year_zero=has_year_zero)
+            return DatetimeGregorian(*add_timedelta(dt, delta, is_leap_gregorian, True, has_year_zero),has_year_zero=has_year_zero)
         elif calendar == 'proleptic_gregorian':
             #return dt.__class__(*add_timedelta(dt, delta, is_leap_proleptic_gregorian, False, has_year_zero),calendar=calendar,has_year_zero=has_year_zero)
             return DatetimeProlepticGregorian(*add_timedelta(dt, delta, is_leap_proleptic_gregorian, False, has_year_zero),has_year_zero=has_year_zero)
@@ -1458,7 +1458,7 @@ datetime object."""
                 elif self.calendar == 'standard':
                     #return self.__class__(*add_timedelta(self, -other, 
                     #     is_leap_gregorian, True, has_year_zero),calendar=self.calendar,has_year_zero=self.has_year_zero)
-                    return DatetimeStandard(*add_timedelta(self, -other, is_leap_gregorian, True, has_year_zero),has_year_zero=self.has_year_zero)
+                    return DatetimeGregorian(*add_timedelta(self, -other, is_leap_gregorian, True, has_year_zero),has_year_zero=self.has_year_zero)
                 elif self.calendar == 'proleptic_gregorian':
                     #return self.__class__(*add_timedelta(self, -other,
                     #    is_leap_proleptic_gregorian, False, has_year_zero),calendar=self.calendar,has_year_zero=self.has_year_zero)

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -1050,9 +1050,9 @@ The default format of the string produced by strftime is controlled by self.form
         if calendar == 'gregorian' or calendar == 'standard':
             # dates after 1582-10-15 can be converted to and compared to
             # proleptic Gregorian dates
-            if calendar == 'gregorian':
-                msg="calendar name 'gregorian' deprecated in CF v1.9 (use 'standard' instead)"
-                warnings.warn(msg,category=DeprecationWarning)
+            #if calendar == 'gregorian':
+            #    msg="calendar name 'gregorian' deprecated in CF v1.9 (use 'standard' instead)"
+            #    warnings.warn(msg,category=DeprecationWarning)
             self.calendar = 'standard'
             if self.to_tuple() >= (1582, 10, 15, 0, 0, 0, 0):
                 self.datetime_compatible = True
@@ -1768,8 +1768,8 @@ cdef _check_calendar(calendar):
     calout = calendar
     # remove 'gregorian','noleap','all_leap'
     if calendar == 'gregorian':
-        msg="calendar name 'gregorian' deprecated in CF v1.9 (use 'standard' instead)"
-        warnings.warn(msg,category=DeprecationWarning)
+        #msg="calendar name 'gregorian' deprecated in CF v1.9 (use 'standard' instead)"
+        #warnings.warn(msg,category=DeprecationWarning)
         calout = 'standard'
     if calendar == 'noleap':
         calout = '365_day'

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -67,7 +67,7 @@ est = timezone(timedelta(hours=-5), 'UTC')
 dtime = namedtuple('dtime', ('values', 'units', 'calendar'))
 dateformat =  '%Y-%m-%d %H:%M:%S'
 
-calendars=['gregorian', 'standard', 'proleptic_gregorian', 'noleap', 'julian',\
+calendars=['standard', 'gregorian', 'proleptic_gregorian', 'noleap', 'julian',\
            'all_leap', '365_day', '366_day', '360_day']
 def adjust_calendar(calendar):
     # check for and remove calendar synonyms.

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -2,7 +2,7 @@ import cftime
 from cftime import datetime as datetimex
 from cftime import real_datetime
 from cftime import (Datetime360Day, DatetimeAllLeap,
-                    DatetimeStandard, DatetimeJulian, DatetimeNoLeap,
+                    DatetimeJulian, DatetimeNoLeap,
                     DatetimeGregorian, DatetimeProlepticGregorian, _parse_date,
                     date2index, date2num, num2date,  UNIT_CONVERSION_FACTORS)
 import copy
@@ -662,25 +662,25 @@ class cftimeTestCase(unittest.TestCase):
             assert (d.minute == 0)
             assert (d.second == 0)
         # test dayofwk, dayofyr attribute setting (cftime issue #13)
-        d1 = DatetimeStandard(2020,2,29)
+        d1 = DatetimeGregorian(2020,2,29)
         d2 = real_datetime(2020,2,29)
         assert (d1.dayofwk == d2.dayofwk == 5)
         assert (d1.dayofyr == d2.dayofyr == 60)
-        d1 = DatetimeStandard(2020,2,29,23,59,59)
+        d1 = DatetimeGregorian(2020,2,29,23,59,59)
         d2 = real_datetime(2020,2,29,23,59,59)
         assert (d1.dayofwk == d2.dayofwk == 5)
         assert (d1.dayofyr == d2.dayofyr == 60)
-        d1 = DatetimeStandard(2020,2,28,23,59,59)
+        d1 = DatetimeGregorian(2020,2,28,23,59,59)
         d2 = real_datetime(2020,2,28,23,59,59)
         assert (d1.dayofwk == d2.dayofwk == 4)
         assert (d1.dayofyr == d2.dayofyr == 59)
-        d1 = DatetimeStandard(1700,1,1)
+        d1 = DatetimeGregorian(1700,1,1)
         d2 = real_datetime(1700,1,1)
         assert (d1.dayofwk == d2.dayofwk == 4)
         assert (d1.dayofyr == d2.dayofyr == 1)
         # last day of Julian Calendar (Thursday)
         d1 = DatetimeJulian(1582, 10, 4, 12)
-        d2 = DatetimeStandard(1582, 10, 4, 12)
+        d2 = DatetimeGregorian(1582, 10, 4, 12)
         d2g = DatetimeGregorian(1582, 10, 4, 12) # deprecated
         assert (d2 == d2g)
         assert (d1.dayofwk == d2.dayofwk == 3)
@@ -779,7 +779,7 @@ class cftimeTestCase(unittest.TestCase):
 #  check that time range of 200,000 + years can be represented accurately
         calendar='standard'
         _MAX_INT64 = np.iinfo("int64").max
-        refdate = DatetimeStandard(292277,10,24,0,0,1)
+        refdate = DatetimeGregorian(292277,10,24,0,0,1)
         for unit in ['microseconds','milliseconds','seconds']:
             units = '%s since 01-01-01' % unit
             time = 292471*365*86400*(1000000//int(UNIT_CONVERSION_FACTORS[unit])) + 1000000//int(UNIT_CONVERSION_FACTORS[unit])
@@ -793,7 +793,7 @@ class cftimeTestCase(unittest.TestCase):
                 assert(date2 == refdate)
 # microsecond roundtrip accuracy preserved over time ranges of 286 years
 # (float64 can only represent integers exactly up to 2**53-1)
-        refdate=DatetimeStandard(286,6,3,23,47,34,740992)
+        refdate=DatetimeGregorian(286,6,3,23,47,34,740992)
         for unit in ['microseconds','milliseconds','seconds','hours','days']:
             units = '%s since 01-01-01' % unit
             time = (2**53 - 1)*(1/UNIT_CONVERSION_FACTORS[unit]) + 1/UNIT_CONVERSION_FACTORS[unit]
@@ -851,9 +851,9 @@ class cftimeTestCase(unittest.TestCase):
 
         # issue #211
         # (masked array handling in date2num - AttributeError:
-        # 'cftime._cftime.DatetimeStandard' object has no attribute 'view')
+        # 'cftime._cftime.DatetimeGregorian' object has no attribute 'view')
         m = np.ma.asarray(
-            [cftime.DatetimeStandard(2014, 8, 1, 12, 0, 0, 0)]
+            [cftime.DatetimeGregorian(2014, 8, 1, 12, 0, 0, 0)]
             )
         assert(
              cftime.date2num(m, units="seconds since 2000-1-1")==[4.602096e+08]
@@ -1164,17 +1164,17 @@ class DateTime(unittest.TestCase):
     def setUp(self):
         self.date1_365_day = DatetimeNoLeap(-5000, 1, 2, 12)
         self.date2_365_day = DatetimeNoLeap(-5000, 1, 3, 12)
-        self.date3_gregorian = DatetimeStandard(1969,  7, 20, 12)
-        self.date3_gregorian_yearzero = DatetimeStandard(1969,  7, 20, 12, has_year_zero=True)
+        self.date3_gregorian = DatetimeGregorian(1969,  7, 20, 12)
+        self.date3_gregorian_yearzero = DatetimeGregorian(1969,  7, 20, 12, has_year_zero=True)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore",category=cftime.CFWarning)
             self.date4_proleptic_gregorian = cftime.datetime(-1,5,5,2,30,59,999999,calendar='proleptic_gregorian',has_year_zero=False)
         self.date4_julian = self.date4_proleptic_gregorian.change_calendar('julian',True)
 
         # last day of the Julian calendar in the mixed Julian/Gregorian calendar
-        self.date4_gregorian = DatetimeStandard(1582, 10, 4)
+        self.date4_gregorian = DatetimeGregorian(1582, 10, 4)
         # first day of the Gregorian calendar in the mixed Julian/Gregorian calendar
-        self.date5_gregorian = DatetimeStandard(1582, 10, 15)
+        self.date5_gregorian = DatetimeGregorian(1582, 10, 15)
 
         self.date6_proleptic_gregorian = DatetimeProlepticGregorian(1582, 10, 15)
 
@@ -1199,19 +1199,19 @@ class DateTime(unittest.TestCase):
 
         # test the Julian/Gregorian transition
         self.assertEqual(self.date4_gregorian + self.delta,
-                         DatetimeStandard(1582, 10, 15, 1))
+                         DatetimeGregorian(1582, 10, 15, 1))
 
         # The Julian calendar has no invalid dates
         self.assertEqual(self.date8_julian + self.delta,
                          DatetimeJulian(1582, 10, 5, 1))
 
         # Test going over the year boundary.
-        self.assertEqual(DatetimeStandard(2000, 11, 1) + timedelta(days=30 + 31),
-                         DatetimeStandard(2001, 1, 1))
+        self.assertEqual(DatetimeGregorian(2000, 11, 1) + timedelta(days=30 + 31),
+                         DatetimeGregorian(2001, 1, 1))
 
         # Year 2000 is a leap year.
-        self.assertEqual(DatetimeStandard(2000, 1, 1) + timedelta(days=31 + 29),
-                         DatetimeStandard(2000, 3, 1))
+        self.assertEqual(DatetimeGregorian(2000, 1, 1) + timedelta(days=31 + 29),
+                         DatetimeGregorian(2000, 3, 1))
 
         # Test the 366_day calendar.
         self.assertEqual(DatetimeAllLeap(1, 1, 1) + timedelta(days=366 * 10 + 31),
@@ -1220,8 +1220,8 @@ class DateTime(unittest.TestCase):
         # The Gregorian calendar has no year zero.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore",category=cftime.CFWarning)
-            self.assertEqual(DatetimeStandard(-1, 12, 31) + self.delta,
-                             DatetimeStandard(1, 1, 1, 1))
+            self.assertEqual(DatetimeGregorian(-1, 12, 31) + self.delta,
+                             DatetimeGregorian(1, 1, 1, 1))
 
         def invalid_add_1():
             self.date1_365_day + 1
@@ -1260,7 +1260,7 @@ class DateTime(unittest.TestCase):
 
         # Test the Julian/Gregorian transition.
         self.assertEqual(self.date5_gregorian - self.delta,
-                         DatetimeStandard(1582, 10, 3, 23))
+                         DatetimeGregorian(1582, 10, 3, 23))
 
         # The proleptic Gregorian calendar does not have invalid dates.
         self.assertEqual(self.date6_proleptic_gregorian - self.delta,
@@ -1269,8 +1269,8 @@ class DateTime(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore",category=cftime.CFWarning)
             # The Gregorian calendar has no year zero.
-            self.assertEqual(DatetimeStandard(1, 1, 1) - self.delta,
-                             DatetimeStandard(-1, 12, 30, 23))
+            self.assertEqual(DatetimeGregorian(1, 1, 1) - self.delta,
+                             DatetimeGregorian(-1, 12, 30, 23))
 
         # The 360_day calendar has year zero.
 
@@ -1278,12 +1278,12 @@ class DateTime(unittest.TestCase):
                          Datetime360Day(0, 1, 1))
 
         # Test going over the year boundary.
-        self.assertEqual(DatetimeStandard(2000, 3, 1) - timedelta(days=29 + 31 + 31),
-                         DatetimeStandard(1999, 12, 1))
+        self.assertEqual(DatetimeGregorian(2000, 3, 1) - timedelta(days=29 + 31 + 31),
+                         DatetimeGregorian(1999, 12, 1))
 
         # Year 2000 is a leap year.
-        self.assertEqual(DatetimeStandard(2000, 3, 1) - self.delta,
-                         DatetimeStandard(2000, 2, 28, 23))
+        self.assertEqual(DatetimeGregorian(2000, 3, 1) - self.delta,
+                         DatetimeGregorian(2000, 2, 28, 23))
 
         def invalid_sub_1():
             self.date1_365_day - 1
@@ -1345,16 +1345,16 @@ class DateTime(unittest.TestCase):
         def invalid_year():
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore",category=cftime.CFWarning)
-                DatetimeStandard(0, 1, 1, has_year_zero=False) + self.delta
+                DatetimeGregorian(0, 1, 1, has_year_zero=False) + self.delta
 
         def invalid_month():
-            DatetimeStandard(1, 13, 1) + self.delta
+            DatetimeGregorian(1, 13, 1) + self.delta
 
         def invalid_day():
-            DatetimeStandard(1, 1, 32) + self.delta
+            DatetimeGregorian(1, 1, 32) + self.delta
 
         def invalid_gregorian_date():
-            DatetimeStandard(1582, 10, 5) + self.delta
+            DatetimeGregorian(1582, 10, 5) + self.delta
 
         for func in [invalid_year, invalid_month, invalid_day, invalid_gregorian_date]:
             self.assertRaises(ValueError, func)
@@ -1455,7 +1455,7 @@ class issue57TestCase(unittest.TestCase):
 
 
 _DATE_TYPES = [DatetimeNoLeap, DatetimeAllLeap, DatetimeJulian, Datetime360Day,
-               DatetimeStandard, DatetimeProlepticGregorian]
+               DatetimeGregorian, DatetimeProlepticGregorian]
 
 
 @pytest.fixture(params=_DATE_TYPES)
@@ -1482,7 +1482,7 @@ def days_per_month_non_leap_year(date_type, month):
 def days_per_month_leap_year(date_type, month):
     if date_type is Datetime360Day:
         return [-1, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30][month]
-    if date_type in [DatetimeStandard, DatetimeProlepticGregorian,
+    if date_type in [DatetimeGregorian, DatetimeProlepticGregorian,
                      DatetimeJulian, DatetimeAllLeap]:
         return [-1, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month]
     else:
@@ -1581,7 +1581,7 @@ def test_valid_sub_day_reso_dates(date_type, date_args):
     'date_args',
     [(1582, 10, 5), (1582, 10, 14)], ids=['lower-bound', 'upper-bound'])
 def test_invalid_julian_gregorian_mixed_dates(date_type, date_args):
-    if date_type is DatetimeStandard:
+    if date_type is DatetimeGregorian:
         with pytest.raises(ValueError):
             date_type(*date_args)
     else:
@@ -1613,7 +1613,7 @@ _EXPECTED_DATE_TYPES = {'noleap': DatetimeNoLeap,
                         '366_day': DatetimeAllLeap,
                         'gregorian': DatetimeGregorian,
                         'proleptic_gregorian': DatetimeProlepticGregorian,
-                        'standard': DatetimeStandard}
+                        'standard': DatetimeGregorian}
 
 
 @pytest.mark.parametrize(

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -3,7 +3,8 @@ from cftime import datetime as datetimex
 from cftime import real_datetime
 from cftime import (Datetime360Day, DatetimeAllLeap,
                     DatetimeJulian, DatetimeNoLeap,
-                    DatetimeGregorian, DatetimeProlepticGregorian, _parse_date,
+                    DatetimeGregorian, DatetimeJulian, DatetimeNoLeap,
+                    DatetimeProlepticGregorian, _parse_date,
                     date2index, date2num, num2date,  UNIT_CONVERSION_FACTORS)
 import copy
 import operator
@@ -678,8 +679,6 @@ class cftimeTestCase(unittest.TestCase):
         # last day of Julian Calendar (Thursday)
         d1 = DatetimeJulian(1582, 10, 4, 12)
         d2 = DatetimeGregorian(1582, 10, 4, 12)
-        d2g = DatetimeGregorian(1582, 10, 4, 12) # deprecated
-        assert (d2 == d2g)
         assert (d1.dayofwk == d2.dayofwk == 3)
         assert (d1.dayofyr == d2.dayofyr == 277)
         # Monday in proleptic gregorian calendar

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -648,6 +648,13 @@ class cftimeTestCase(unittest.TestCase):
         # cftime issue #52
         with warnings.catch_warnings():
             warnings.simplefilter("ignore",category=cftime.CFWarning)
+            d = cftime.datetime.fromordinal(1684958.5,calendar='gregorian')
+            assert (d.year == -100)
+            assert (d.month == 3)
+            assert (d.day == 2)
+            assert (d.hour == 0)
+            assert (d.minute == 0)
+            assert (d.second == 0)
             d = cftime.datetime.fromordinal(1684958.5,calendar='standard')
             assert (d.year == -100)
             assert (d.month == 3)
@@ -1904,6 +1911,7 @@ def test_num2date_use_pydatetime_if_possible(calendar, shape, dtype):
 @pytest.mark.parametrize(
     ["standard_calendar", "breakpoint"],
     [("proleptic_gregorian", "{}-12-31T23:59:59.999999".format(MINYEAR - 1)),
+     ("gregorian", "1582-10-15"),
      ("standard", "1582-10-15")]
 )
 def test_num2date_only_use_python_datetimes_invalid_basedate(

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -307,9 +307,6 @@ class cftimeTestCase(unittest.TestCase):
         self.assertTrue(str(d) == str(date))
         # test julian day from date, date from julian day
         d = cftime.datetime(1858, 11, 17, calendar='standard')
-        dg = cftime.datetime(1858, 11, 17, calendar='gregorian') # deprecated
-        assert(d == dg)
-        assert_almost_equal(dg.toordinal(fractional=True), 2400000.5)
         # astronomical year numbering (with year zero)
         dz = cftime.datetime(1858, 11, 17, calendar='standard',has_year_zero=True)
         # toordinal (with fractional = True) is same as old JulianDayFromDate

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -2,7 +2,6 @@ import cftime
 from cftime import datetime as datetimex
 from cftime import real_datetime
 from cftime import (Datetime360Day, DatetimeAllLeap,
-                    DatetimeJulian, DatetimeNoLeap,
                     DatetimeGregorian, DatetimeJulian, DatetimeNoLeap,
                     DatetimeProlepticGregorian, _parse_date,
                     date2index, date2num, num2date,  UNIT_CONVERSION_FACTORS)

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -307,9 +307,8 @@ class cftimeTestCase(unittest.TestCase):
         self.assertTrue(str(d) == str(date))
         # test julian day from date, date from julian day
         d = cftime.datetime(1858, 11, 17, calendar='standard')
-        #with warnings.catch_warnings():
-        #    warnings.simplefilter("ignore",category=DeprecationWarning)
         dg = cftime.datetime(1858, 11, 17, calendar='gregorian') # deprecated
+        assert(d == dg)
         assert_almost_equal(dg.toordinal(fractional=True), 2400000.5)
         # astronomical year numbering (with year zero)
         dz = cftime.datetime(1858, 11, 17, calendar='standard',has_year_zero=True)
@@ -1612,6 +1611,7 @@ _EXPECTED_DATE_TYPES = {'noleap': DatetimeNoLeap,
                         'julian': DatetimeJulian,
                         'all_leap': DatetimeAllLeap,
                         '366_day': DatetimeAllLeap,
+                        'gregorian': DatetimeGregorian,
                         'proleptic_gregorian': DatetimeProlepticGregorian,
                         'standard': DatetimeStandard}
 

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -67,7 +67,7 @@ est = timezone(timedelta(hours=-5), 'UTC')
 dtime = namedtuple('dtime', ('values', 'units', 'calendar'))
 dateformat =  '%Y-%m-%d %H:%M:%S'
 
-calendars=['standard', 'proleptic_gregorian', 'noleap', 'julian',\
+calendars=['gregorian', 'standard', 'proleptic_gregorian', 'noleap', 'julian',\
            'all_leap', '365_day', '366_day', '360_day']
 def adjust_calendar(calendar):
     # check for and remove calendar synonyms.
@@ -769,7 +769,7 @@ class cftimeTestCase(unittest.TestCase):
         test = dates == np.ma.masked_array([datetime(1848, 1, 17, 6, 0, 0, 40), None],mask=[0,1])
         assert(test.all())
         dates = num2date(times, units=units, calendar='standard')
-        assert(str(dates)=="[cftime.DatetimeStandard(1848, 1, 17, 6, 0, 0, 40, has_year_zero=False) --]")
+        assert(str(dates)=="[cftime.DatetimeGregorian(1848, 1, 17, 6, 0, 0, 40, has_year_zero=False)\n --]")
 #  check that time range of 200,000 + years can be represented accurately
         calendar='standard'
         _MAX_INT64 = np.iinfo("int64").max

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -307,10 +307,10 @@ class cftimeTestCase(unittest.TestCase):
         self.assertTrue(str(d) == str(date))
         # test julian day from date, date from julian day
         d = cftime.datetime(1858, 11, 17, calendar='standard')
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore",category=DeprecationWarning)
-            dg = cftime.datetime(1858, 11, 17, calendar='gregorian') # deprecated
-            assert_almost_equal(dg.toordinal(fractional=True), 2400000.5)
+        #with warnings.catch_warnings():
+        #    warnings.simplefilter("ignore",category=DeprecationWarning)
+        dg = cftime.datetime(1858, 11, 17, calendar='gregorian') # deprecated
+        assert_almost_equal(dg.toordinal(fractional=True), 2400000.5)
         # astronomical year numbering (with year zero)
         dz = cftime.datetime(1858, 11, 17, calendar='standard',has_year_zero=True)
         # toordinal (with fractional = True) is same as old JulianDayFromDate


### PR DESCRIPTION
add a DeprecationWarning if calendar='gregorian' used, replace DatetimeGregorian with DatetimeStandard (but keep DatetimeGregorian for backwards compatibility)