### PR TITLE
Implement optimized `num2date` algorithm

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,8 @@
 since version 1.5.2
 ===================
  * fix for masked array inputs (issue #267).
+ * improved performance of the num2date algorithm, in some cases providing
+   an over 100x speedup (issue #269, PR#270).
 
 version 1.5.2 (release tag v1.5.2rel)
 =====================================

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -2058,7 +2058,32 @@ def test_date2num_missing_data():
     out = date2num(array, units="days since 2000-12-01", calendar="standard")
     assert out is np.ma.masked
 
-    
+
+def test_num2date_preserves_shape():
+    # The optimized num2date algorithm operates on a flattened array.  This
+    # check ensures that the original shape of the times is restored in the 
+    # result.
+    a = np.array([[0, 1, 2], [3, 4, 5]])
+    result = num2date(a, units="days since 2000-01-01", calendar="standard")
+    expected = np.array([cftime.DatetimeGregorian(2000, 1, i) for i in range(1, 7)]).reshape((2, 3))
+    np.testing.assert_equal(result, expected)
+
+
+def test_num2date_preserves_order():
+    # The optimized num2date algorithm sorts the encoded times before decoding them.
+    # This check ensures that the order of the times is restored in the result.
+    a = np.array([1, 0])
+    result = num2date(a, units="days since 2000-01-01", calendar="standard")
+    expected = np.array([cftime.DatetimeGregorian(2000, 1, i) for i in [2, 1]])
+    np.testing.assert_equal(result, expected)
+
+
+def test_num2date_empty_array():
+    a = np.array([[]])
+    result = num2date(a, units="days since 2000-01-01", calendar="standard")
+    expected = np.array([[]], dtype="O")
+    np.testing.assert_equal(result, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This implements the "Iterate using relative timedeltas with sorting" approach described in #269, handling the zero-size and masked array edge cases as well.  It addresses the performance issue associated with using a distant reference date in encoding the times (what originally motivated this work), and also provides a nice performance boost for time arrays that span a long time range.

While other simpler approaches can be marginally faster in some circumstances, this approach is definitely the most robust to different arrangements of times (the "Unordered long" case in #269 being the most difficult for other algorithms). 

Thanks @rabernat for the clever idea!