### PR TITLE
fix for issue #272

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,8 @@ version 1.6.0 (not yet released)
  * fix for masked array inputs (issue #267).
  * improved performance of the num2date algorithm, in some cases providing
    an over 100x speedup (issue #269, PR#270).
+ * fix for date2index for select != 'exact' when select='exact' works (issue
+   #272, PR#273)
 
 version 1.5.2 (release tag v1.5.2rel)
 =====================================

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -891,6 +891,20 @@ def time2index(times, nctime, calendar=None, select='exact'):
     if calendar == None:
         calendar = getattr(nctime, 'calendar', 'standard')
 
+    if select != 'exact':
+        # if select works, then 'nearest' == 'exact', 'before' == 'exact'-1 and
+        # 'after' == 'exact'+1
+        try:
+            index = time2index(times, nctime, calendar=calendar, select='exact')
+            if select == 'nearest':
+                return index
+            elif select == 'before':
+                return index-1
+            else:
+                return index+1
+        except ValueError:
+            pass
+
     num = np.atleast_1d(times)
     N = len(nctime)
 

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -961,6 +961,10 @@ class TestDate2index(unittest.TestCase):
         self.standardtime = self.TestTime(datetime(1950, 1, 1), 366, 24,
                                           'hours since 1900-01-01', 'standard')
 
+        self.issue272time = self.TestTime(datetime(1950, 1, 1), 5, 24,
+                                          'hours since 1900-01-01', 'standard')
+        self.issue272time._data=np.array([1053144, 1053150, 1053156, 1053157,
+            1053162],np.int32)
         self.time_vars = {}
         self.time_vars['time'] = CFTimeVariable(
             values=self.standardtime,
@@ -1116,6 +1120,18 @@ class TestDate2index(unittest.TestCase):
         index = date2index(query_time, self.time_vars['time3'],
                            select='nearest')
         assert(index == 11)
+
+    def test_issue272(self):
+        timeArray = self.issue272time
+        date = datetime(2020, 2, 22, 13)
+        assert(date2index(date, timeArray, calendar="gregorian",
+            select="exact")==3)
+        assert(date2index(date, timeArray, calendar="gregorian",
+            select="before")==2)
+        assert(date2index(date, timeArray, calendar="gregorian",
+            select="after")==4)
+        assert(date2index(date, timeArray, calendar="gregorian",
+            select="nearest")==3)
 
 
 class issue584TestCase(unittest.TestCase):


### PR DESCRIPTION
potential fix for date2index with `select='nearest','before','after'` when `'exact'` works.