### PR TITLE
Add %f to strftime method and make 4-digit negative years

### DIFF
--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -1280,25 +1280,43 @@ The default format of the string produced by strftime is controlled by self.form
     def __str__(self):
         return self.isoformat(' ')
 
-    def isoformat(self,sep='T',timespec='auto'):
-        second = ":%02i" %self.second
-        if (timespec == 'auto' and self.microsecond) or timespec == 'microseconds':
-            second += ".%06i" % self.microsecond
-        if timespec == 'milliseconds':
-            millisecs = self.microsecond/1000
-            second += ".%03i" % millisecs
-        if timespec in ['auto', 'microseconds', 'milliseconds']:
-            return "%04i-%02i-%02i%s%02i:%02i%s" %\
-            (self.year, self.month, self.day, sep, self.hour, self.minute, second)
-        elif timespec == 'seconds':
-            return "%04i-%02i-%02i%s%02i:%02i:%02i" %\
-            (self.year, self.month, self.day, sep, self.hour, self.minute, self.second)
-        elif timespec == 'minutes':
-            return "%04i-%02i-%02i%s%02i:%02i" %\
-            (self.year, self.month, self.day, sep, self.hour, self.minute)
+    def isoformat(self, sep='T', timespec='auto'):
+        """
+        ISO date representation
+
+        """
+        if self.year < 0:
+            form0 = '{:05d}-{:02d}-{:02d}'
+        else:
+            form0 = '{:04d}-{:02d}-{:02d}'
+        if timespec == 'days':
+            form = form0
+            return form.format(self.year, self.month, self.day)
         elif timespec == 'hours':
-            return "%04i-%02i-%02i%s%02i" %\
-            (self.year, self.month, self.day, sep, self.hour)
+            form = form0 + '{:s}{:02d}'
+            return form.format(self.year, self.month, self.day, sep,
+                               self.hour)
+        elif timespec == 'minutes':
+            form = form0 + '{:s}{:02d}:{:02d}'
+            return form.format(self.year, self.month, self.day, sep,
+                               self.hour, self.minute)
+        elif timespec == 'seconds':
+            form = form0 + '{:s}{:02d}:{:02d}:{:02d}'
+            return form.format(self.year, self.month, self.day, sep,
+                               self.hour, self.minute, self.second)
+        elif timespec in ['auto', 'microseconds', 'milliseconds']:
+            second = '{:02d}'.format(self.second)
+            if timespec == 'milliseconds':
+                millisecs = int(round(self.microsecond / 1000, 0))
+                second += '.{:03d}'.format(millisecs)
+            elif timespec == 'microseconds':
+                second += '.{:06d}'.format(self.microsecond)
+            else:
+                if self.microsecond > 0:
+                    second += '.{:06d}'.format(self.microsecond)
+            form = form0 + '{:s}{:02d}:{:02d}:{:s}'
+            return form.format(self.year, self.month, self.day, sep,
+                               self.hour, self.minute, second)
         else:
             raise ValueError('illegal timespec')
 
@@ -1565,14 +1583,24 @@ cdef _findall(text, substr):
 # Every 28 years the calendar repeats, except through century leap
 # years where it's 6 years.  But only if you're using the Gregorian
 # calendar.  ;)
-
-
+# Make also 4-digit negative years
+# Allow .%f for microseconds
 cdef _strftime(datetime dt, fmt):
     if _illegal_s.search(fmt):
         raise TypeError("This strftime implementation does not handle %s")
     # don't use strftime method at all.
     # if dt.year > 1900:
     #    return dt.strftime(fmt)
+    if '%f' in fmt:
+        if not fmt.endswith('.%f'):
+            raise TypeError('If %f is used for microseconds it must be the'
+                            ' at the end as .%f')
+        else:
+            ihavems = True
+            fmt1 = fmt[:-3]
+    else:
+        ihavems = False
+        fmt1 = fmt
 
     year = dt.year
     # For every non-leap year century, advance by
@@ -1584,10 +1612,10 @@ cdef _strftime(datetime dt, fmt):
     # Move to around the year 2000
     year = year + ((2000 - year) // 28) * 28
     timetuple = dt.timetuple()
-    s1 = time.strftime(fmt, (year,) + timetuple[1:])
+    s1 = time.strftime(fmt1, (year,) + timetuple[1:])
     sites1 = _findall(s1, str(year))
 
-    s2 = time.strftime(fmt, (year + 28,) + timetuple[1:])
+    s2 = time.strftime(fmt1, (year + 28,) + timetuple[1:])
     sites2 = _findall(s2, str(year + 28))
 
     sites = []
@@ -1596,9 +1624,14 @@ cdef _strftime(datetime dt, fmt):
             sites.append(site)
 
     s = s1
-    syear = "%04d" % (dt.year,)
+    if dt.year < 0:
+        syear = "%05d" % (dt.year,)
+    else:
+        syear = "%04d" % (dt.year,)
     for site in sites:
         s = s[:site] + syear + s[site + 4:]
+    if ihavems:
+        s = s + '.{:06d}'.format(dt.microsecond)
     return s
 
 cdef bint is_leap_julian(int year, bint has_year_zero):

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -751,7 +751,7 @@ class cftimeTestCase(unittest.TestCase):
         # issue #152 add isoformat()
         assert(d.isoformat()[0:24] == '2009-12-22T00:00:00.0156')
         assert(d.isoformat(sep=' ')[0:24] == '2009-12-22 00:00:00.0156')
-        assert(d.isoformat(sep=' ',timespec='milliseconds') == '2009-12-22 00:00:00.015')
+        assert(d.isoformat(sep=' ',timespec='milliseconds') == '2009-12-22 00:00:00.016')
         assert(d.isoformat(sep=' ',timespec='seconds') == '2009-12-22 00:00:00')
         assert(d.isoformat(sep=' ',timespec='minutes') == '2009-12-22 00:00')
         assert(d.isoformat(sep=' ',timespec='hours') == '2009-12-22 00')
@@ -1685,6 +1685,36 @@ def test_string_format():
     # check a given format string acts like strftime
     assert dt.strftime('%H%m%d') == '{0:%H%m%d}'.format(dt)
     assert 'the year is 2000' == 'the year is {dt:%Y}'.format(dt=dt)
+
+
+def test_string_format2():
+    dt = cftime.datetime(-4713, 1, 1, 12, 0, 0, 10)
+    # check a given format string acts like strftime
+    assert dt.strftime('%H%m%d') == '{0:%H%m%d}'.format(dt)
+    assert dt.strftime() == '-4713-01-01 12:00:00'
+    assert dt.strftime('%Y-%m-%d %H:%M:%S') == '-4713-01-01 12:00:00'
+    assert dt.strftime('%Y-%m-%d %H:%M:%S.%f') == '-4713-01-01 12:00:00.000010'
+    assert dt.strftime('%d.%m.%Y %H:%M:%S.%f') == '01.01.-4713 12:00:00.000010'
+    dt = cftime.datetime(-713, 1, 1, 12, 0, 0, 10)
+    assert dt.strftime('%H%m%d') == '{0:%H%m%d}'.format(dt)
+    assert dt.strftime() == '-0713-01-01 12:00:00'
+    assert dt.strftime('%Y-%m-%d %H:%M:%S') == '-0713-01-01 12:00:00'
+    assert dt.strftime('%Y-%m-%d %H:%M:%S.%f') == '-0713-01-01 12:00:00.000010'
+    assert dt.strftime('%d.%m.%Y %H:%M:%S.%f') == '01.01.-0713 12:00:00.000010'
+
+
+def test_string_isoformat():
+    dt = cftime.datetime(-4713, 1, 1, 12, 0, 0, 10)
+    assert dt.isoformat() == '-4713-01-01T12:00:00.000010'
+    assert dt.isoformat(' ', 'days') == '-4713-01-01'
+    assert dt.isoformat(' ', 'seconds') == '-4713-01-01 12:00:00'
+    assert dt.isoformat(' ', 'microseconds') == '-4713-01-01 12:00:00.000010'
+    dt = cftime.datetime(-713, 1, 1, 12, 0, 0, 10)
+    assert dt.isoformat() == '-0713-01-01T12:00:00.000010'
+    assert dt.isoformat(' ', 'days') == '-0713-01-01'
+    assert dt.isoformat(' ', 'seconds') == '-0713-01-01 12:00:00'
+    assert dt.isoformat(' ', 'microseconds') == '-0713-01-01 12:00:00.000010'
+
 
 def test_dayofyr_after_replace(date_type):
     date = date_type(1, 1, 1)


### PR DESCRIPTION
I added that strftime understands the %f format for fraction of seconds. Currently, it has to be at the end of the format string.
```
from cftime import datetime
dt = cftime.datetime(-4713, 1, 1, 12, 0, 0, 10)
dt.strftime('%Y-%m-%d %H:%M:%S.%f')

```
gave:
`-4713-01-01 12:00:00.f`
Now it gives:
`-4713-01-01 12:00:00.000010`
which is the same as `isoformat(' ')`.

I also added that negative years have also 4 digits
```
dt = cftime.datetime(-713, 1, 1, 12, 0, 0, 10)
dt.strftime('%Y-%m-%d %H:%M:%S')

```
gave:
`-713-01-01 12:00:00`
Now it gives:
`-0713-01-01 12:00:00`

I rewrote isoformat. It is pretty much the same but has a an extra timespec 'days'.
There is a difference though that milliseconds round now while it seems that they were simply truncated before. At least I had to change line 754 in test_cftime.py, which gave '2009-12-22 00:00:00.015' before and now is '2009-12-22 00:00:00.016' for the original '2009-12-22 00:00:00.0156'. I do not know it this was intended.

Kind regards,
Matthias
