### PR TITLE
Add improved error message for unrecognized units

### DIFF
--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -101,7 +101,11 @@ def _dateparse(timestr,calendar,has_year_zero=None):
             raise ValueError("'%s' units only allowed for '365_day' and 'noleap' calendars" % units) 
         else:
             raise ValueError(
-            "units must be one of 'seconds', 'minutes', 'hours' or 'days' (or singular version of these), got '%s'" % units)
+            "In general, units must be one of 'microseconds', 'milliseconds', "
+            "'seconds', 'minutes', 'hours', or 'days' (or select abbreviated "
+            "versions of these).  For the '360_day' calendar, "
+            "'months' can also be used, or for the 'noleap' calendar 'common_years' "
+            "can also be used. Got '%s' instead, which are not recognized." % units)
     # parse the date string.
     year, month, day, hour, minute, second, microsecond, utc_offset =\
         _parse_date( isostring.strip() )

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -2101,5 +2101,25 @@ def test_num2date_empty_array():
     np.testing.assert_equal(result, expected)
 
 
+DATEPARSE_ERROR_TESTS = [
+    ("foo", "In general, units must be"),
+    ("months", "'months since' units only allowed"),
+    ("common_years", "'common_years' units only allowed")
+]
+
+
+@pytest.mark.parametrize(("units", "match"), DATEPARSE_ERROR_TESTS)
+def test_num2date_unrecognized_units(units, match):
+    with pytest.raises(ValueError, match=match):
+        num2date(0.0, units=f"{units} since 2000-01-01", calendar="standard")
+
+
+@pytest.mark.parametrize(("units", "match"), DATEPARSE_ERROR_TESTS)
+def test_date2num_unrecognized_units(units, match):
+    date = cftime.datetime(2000, 1, 1, calendar="standard")
+    with pytest.raises(ValueError, match=match):
+        date2num(date, units=f"{units} since 2000-01-01", calendar="standard")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Per https://github.com/Unidata/cftime/pull/284#issuecomment-1172888458 this adds an improved error message for when parsing the time units fails:

```
>>> import cftime
>>> cftime.num2date(0, units="foo since 2000-01-01")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "src/cftime/_cftime.pyx", line 553, in cftime._cftime.num2date
  File "src/cftime/_cftime.pyx", line 103, in cftime._cftime._dateparse
ValueError: In general, units must be one of 'microseconds', 'milliseconds', 'seconds', 'minutes', 'hours', or 'days' (or select abbreviated versions of these).  For the '360_day' calendar, 'months' can also be used, or for the 'noleap' calendar 'common_years' can also be used. Got 'foo' instead, which are not recognized.
```