### PR TITLE
add a strptime static method (issue #277)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,9 +1,10 @@
-since version 1.6.1 release
-===========================
+version 1.6.2 (not yet released)
+================================
  * num2date should not fail on an empty integer array (issue #287).
  * longdouble keyword in date2num so that a roundtrip from a time to a date
    and back again does not lose microsecond precision when the units require
    the times be encoded as floating point values (PR #284)
+ * added strptime method (issue #277).
 
 version 1.6.1 (release tag v1.6.1rel)
 =====================================

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -38,7 +38,7 @@ cdef int[12] _dayspermonth_leap = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 3
 cdef int[13] _cumdayspermonth = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365]
 cdef int[13] _cumdayspermonth_leap = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366]
 
-__version__ = '1.6.1'
+__version__ = '1.6.2'
 
 # Adapted from http://delete.me.uk/2005/03/iso8601.html
 # Note: This regex ensures that all ISO8601 timezone formats are accepted - but, due to legacy support for other timestrings, not all incorrect formats can be rejected.

--- a/src/cftime/_cftime.pyx
+++ b/src/cftime/_cftime.pyx
@@ -225,7 +225,7 @@ def date2num(dates, units, calendar=None, has_year_zero=None, longdouble=False):
             has_year_zero = _year_zero_defaults(calendar)
 
     # if calendar is None or '', use calendar of first input cftime.datetime instances.
-    # if inputs are 'real' python datetime instances, use propleptic gregorian.
+    # if inputs are 'real' python datetime instances, use proleptic gregorian.
     if not calendar:
         if all_python_datetimes:
             calendar = 'proleptic_gregorian'
@@ -695,7 +695,7 @@ def date2index(dates, nctime, calendar=None, select='exact', has_year_zero=None)
             has_year_zero = _year_zero_defaults(calendar)
 
     # if calendar is None or '', use calendar of first input cftime.datetime instances.
-    # if inputs are 'real' python datetime instances, use propleptic gregorian.
+    # if inputs are 'real' python datetime instances, use proleptic gregorian.
     if not calendar:
         d0 = dates_test.item(0)
         if isinstance(d0,datetime_python):
@@ -1236,6 +1236,25 @@ The default format of the string produced by strftime is controlled by self.form
         if format is None:
             format = self.format
         return _strftime(self, format)
+
+    @staticmethod
+    def strptime(datestring, format, calendar='standard', has_year_zero=None):
+        """
+        Return a datetime corresponding to date_string, parsed according to format, 
+        with a specified calendar and year zero convention. 
+        For a complete list of formatting directives, see section
+        'strftime() and strptime() Behavior' in the base Python documentation.
+        """
+        # use python's datetime.strptime to get a python datetime instance
+        # (using proleptic_gregorian calendar)
+        pydatetime = datetime_python.strptime(datestring, format)
+        # remove time zone offset
+        if getattr(pydatetime, 'tzinfo',None) is not None:
+            pydatetime = pydatetime.replace(tzinfo=None) - pydatetime.utcoffset()
+        # convert the cftime datetime instance
+        return datetime(pydatetime.year, pydatetime.month, pydatetime.day,
+                        pydatetime.hour, pydatetime.minute, pydatetime.second,
+                        pydatetime.microsecond, calendar=calendar, has_year_zero=has_year_zero)
 
     def __format__(self, format):
         # the string format "{t_obj}".format(t_obj=t_obj)

--- a/src/cftime/_strptime.py
+++ b/src/cftime/_strptime.py
@@ -1,0 +1,137 @@
+"""stripped-down version of _strptime.py from C python"""
+from re import compile as re_compile
+from re import IGNORECASE
+from re import escape as re_escape
+from _thread import allocate_lock as _thread_allocate_lock
+
+__all__ = []
+
+class TimeRE(dict):
+    """Handle conversion from format directives to regexes."""
+
+    def __init__(self, locale_time=None):
+        """Create keys/values.
+
+        Order of execution is important for dependency reasons.
+
+        """
+        base = super()
+        base.__init__({
+            # The " [1-9]" part of the regex is to make %c from ANSI C work
+            'd': r"(?P<d>3[0-1]|[1-2]\d|0[1-9]|[1-9]| [1-9])",
+            'f': r"(?P<f>[0-9]{1,6})",
+            'H': r"(?P<H>2[0-3]|[0-1]\d|\d)",
+            'I': r"(?P<I>1[0-2]|0[1-9]|[1-9])",
+            'm': r"(?P<m>1[0-2]|0[1-9]|[1-9])",
+            'M': r"(?P<M>[0-5]\d|\d)",
+            'S': r"(?P<S>6[0-1]|[0-5]\d|\d)",
+            'w': r"(?P<w>[0-6])",
+            'y': r"(?P<y>\d\d)",
+            'Y': r"(?P<Y>\d\d\d\d)",
+            '%': '%'})
+
+    def pattern(self, format):
+        """Return regex pattern for the format string.
+        Need to make sure that any characters that might be interpreted as
+        regex syntax are escaped.
+        """
+        processed_format = ''
+        # The sub() call escapes all characters that might be misconstrued
+        # as regex syntax.  Cannot use re.escape since we have to deal with
+        # format directives (%m, etc.).
+        regex_chars = re_compile(r"([\\.^$*+?\(\){}\[\]|])")
+        format = regex_chars.sub(r"\\\1", format)
+        whitespace_replacement = re_compile(r'\s+')
+        format = whitespace_replacement.sub(r'\\s+', format)
+        while '%' in format:
+            directive_index = format.index('%')+1
+            processed_format = "%s%s%s" % (processed_format,
+                                           format[:directive_index-1],
+                                           self[format[directive_index]])
+            format = format[directive_index+1:]
+        return "%s%s" % (processed_format, format)
+
+    def compile(self, format):
+        """Return a compiled re object for the format string."""
+        return re_compile(self.pattern(format), IGNORECASE)
+
+_cache_lock = _thread_allocate_lock()
+# DO NOT modify _TimeRE_cache or _regex_cache without acquiring the cache lock
+# first!
+_TimeRE_cache = TimeRE()
+_CACHE_MAX_SIZE = 5 # Max number of regexes stored in _regex_cache
+_regex_cache = {}
+
+def _strptime(data_string, format="%a %b %d %H:%M:%S %Y"):
+    """Return a 2-tuple consisting of a time struct and an int containing
+    the number of microseconds based on the input string and the
+    format string."""
+
+    for index, arg in enumerate([data_string, format]):
+        if not isinstance(arg, str):
+            msg = "strptime() argument {} must be str, not {}"
+            raise TypeError(msg.format(index, type(arg)))
+
+    global _TimeRE_cache, _regex_cache
+    with _cache_lock:
+        if len(_regex_cache) > _CACHE_MAX_SIZE:
+            _regex_cache.clear()
+        format_regex = _regex_cache.get(format)
+        if not format_regex:
+            try:
+                format_regex = _TimeRE_cache.compile(format)
+            # KeyError raised when a bad format is found; can be specified as
+            # \\, in which case it was a stray % but with a space after it
+            except KeyError as err:
+                bad_directive = err.args[0]
+                if bad_directive == "\\":
+                    bad_directive = "%"
+                del err
+                raise ValueError("'%s' is a bad directive in format '%s'" %
+                                    (bad_directive, format)) from None
+            # IndexError only occurs when the format string is "%"
+            except IndexError:
+                raise ValueError("stray %% in format '%s'" % format) from None
+            _regex_cache[format] = format_regex
+    found = format_regex.match(data_string)
+    if not found:
+        raise ValueError("time data %r does not match format %r" %
+                         (data_string, format))
+    if len(data_string) != found.end():
+        raise ValueError("unconverted data remains: %s" %
+                          data_string[found.end():])
+
+    month = day = 1
+    hour = minute = second = fraction = 0
+    found_dict = found.groupdict()
+    for group_key in found_dict.keys():
+        if group_key == 'y':
+            year = int(found_dict['y'])
+            if year <= 68:
+                year += 2000
+            else:
+                year += 1900
+        elif group_key == 'Y':
+            year = int(found_dict['Y'])
+        elif group_key == 'm':
+            month = int(found_dict['m'])
+        elif group_key == 'b':
+            month = locale_time.a_month.index(found_dict['b'].lower())
+        elif group_key == 'd':
+            day = int(found_dict['d'])
+        elif group_key == 'H':
+            hour = int(found_dict['H'])
+        elif group_key == 'I':
+            hour = int(found_dict['I'])
+            ampm = found_dict.get('p', '').lower()
+        elif group_key == 'M':
+            minute = int(found_dict['M'])
+        elif group_key == 'S':
+            second = int(found_dict['S'])
+        elif group_key == 'f':
+            s = found_dict['f']
+            # Pad to always return microseconds.
+            s += "0" * (6 - len(s))
+            fraction = int(s)
+
+    return year,month,day,hour,minute,second,fraction

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1708,6 +1708,12 @@ def test_string_format2():
 def test_strptime():
     d = cftime.datetime.strptime('24/Aug/2004:17:57:26 +0200', '%d/%b/%Y:%H:%M:%S %z',calendar='julian',has_year_zero=True)
     assert(repr(d) == "cftime.datetime(2004, 8, 24, 15, 57, 26, 0, calendar='julian', has_year_zero=True)")
+    d = cftime.datetime.strptime("0000-02-30",\
+             "%Y-%m-%d",calendar='360_day',has_year_zero=True)
+    assert(repr(d) == "cftime.datetime(0, 2, 30, 0, 0, 0, 0, calendar='360_day', has_year_zero=True)")
+    d = cftime.datetime.strptime('1911-02-29 10:18:32.926',\
+             '%Y-%m-%d %H:%M:%S.%f',calendar='366_day')
+    assert(repr(d) == "cftime.datetime(1911, 2, 29, 10, 18, 32, 926000, calendar='all_leap', has_year_zero=True)")
 
 
 def test_string_isoformat():

--- a/test/test_cftime.py
+++ b/test/test_cftime.py
@@ -1705,6 +1705,10 @@ def test_string_format2():
     assert dt.strftime('%Y-%m-%d %H:%M:%S.%f') == '-0713-01-01 12:00:00.000010'
     assert dt.strftime('%d.%m.%Y %H:%M:%S.%f') == '01.01.-0713 12:00:00.000010'
 
+def test_strptime():
+    d = cftime.datetime.strptime('24/Aug/2004:17:57:26 +0200', '%d/%b/%Y:%H:%M:%S %z',calendar='julian',has_year_zero=True)
+    assert(repr(d) == "cftime.datetime(2004, 8, 24, 15, 57, 26, 0, calendar='julian', has_year_zero=True)")
+
 
 def test_string_isoformat():
     dt = cftime.datetime(-4713, 1, 1, 12, 0, 0, 10)


### PR DESCRIPTION
uses python's datetime.datetime.strptime if possible (for dates in proleptic_gregorian).
for dates that don't work with python's strptime, use a stripped-down version of _strptime.py from C-python that doesn't handle timezones and locales.

TODO: formatting for negative years 

@spencerkclark apologies if you were already working on this - I had some free time this weekend so decided to take a crack at it. 