### PR TITLE
Set `c_api_binop_methods` Cython compiler directive to `True`

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,8 @@ since version 1.6.2 release
 ===========================
  * add support for formats without separators in strptime (e.g. '20200229', issue #301).
    This required removing support for > 4 digit years.
+ * set the c_api_binop_methods compiler directive to True to retain Cython 0.x
+   behavior for arithmetic operators for Cython >= 3.0.0 (issue #271).
 
 version 1.6.2 (release tag v1.6.2rel)
 =====================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=41.2", "cython", "wheel", "oldest-supported-numpy"]
+requires = ["setuptools>=41.2", "cython>=0.29.20", "wheel", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 check-manifest
 coverage
 coveralls
-cython>0.26.1
+cython>=0.29.20
 pytest
 pytest-cov
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,14 @@ except ImportError:
 BASEDIR = os.path.abspath(os.path.dirname(__file__))
 SRCDIR = os.path.join(BASEDIR,'src')
 CMDS_NOCYTHONIZE = ['clean','clean_cython','sdist']
-COMPILER_DIRECTIVES = {}
+COMPILER_DIRECTIVES = {
+    # Cython 3.0.0 changes the default of the c_api_binop_methods directive to
+    # False, resulting in errors in datetime and timedelta arithmetic:
+    # https://github.com/Unidata/cftime/issues/271.  We explicitly set it to
+    # True to retain Cython 0.x behavior for future Cython versions.  This
+    # directive was added in Cython version 0.29.20.
+    "c_api_binop_methods": True
+}
 DEFINE_MACROS = [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")] 
 FLAG_COVERAGE = '--cython-coverage'  # custom flag enabling Cython line tracing
 NAME = 'cftime'


### PR DESCRIPTION
The change described [here](https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#arithmetic-special-methods) appears to be the cause of the errors reported in #271.  The documentation notes that one way to address this is to restore the old arithmetic operator behavior by setting the `c_api_binop_methods` compiler directive to `True`.  This PR makes this change.  I've confirmed locally that it addresses the issue.  

Note that this directive requires Cython >= 0.29.20, [which was released on 2020-06-10](https://cython.readthedocs.io/en/latest/src/changes.html?highlight=c_api_binop_methods#id113); I updated the `pyproject.toml` and `requirements-dev.txt` files accordingly.