### PR TITLE
Update `intersphinx_mapping` format; use `c_api_binop_methods` during coverage installs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -162,4 +162,4 @@ texinfo_documents = [
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,12 @@ COMPILER_DIRECTIVES = {
     # directive was added in Cython version 0.29.20.
     "c_api_binop_methods": True
 }
+COVERAGE_COMPILER_DIRECTIVES = {
+    "linetrace": True,
+    "warn.maybe_uninitialized": False,
+    "warn.unreachable": False,
+    "warn.unused": False,
+}
 DEFINE_MACROS = [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")] 
 FLAG_COVERAGE = '--cython-coverage'  # custom flag enabling Cython line tracing
 NAME = 'cftime'
@@ -81,10 +87,9 @@ def description():
 
 if ((FLAG_COVERAGE in sys.argv or os.environ.get('CYTHON_COVERAGE', None))
     and cythonize):
-    COMPILER_DIRECTIVES = {'linetrace': True,
-                           'warn.maybe_uninitialized': False,
-                           'warn.unreachable': False,
-                           'warn.unused': False}
+    COMPILER_DIRECTIVES = {
+        **COMPILER_DIRECTIVES, **COVERAGE_COMPILER_DIRECTIVES
+    }
     DEFINE_MACROS += [('CYTHON_TRACE', '1'),
                      ('CYTHON_TRACE_NOGIL', '1')]
     if FLAG_COVERAGE in sys.argv:


### PR DESCRIPTION
The following deprecation warning led [the documentation build](https://github.com/Unidata/cftime/actions/runs/5701592450/job/15452452061) to fail after merging #305:

```
Warning, treated as error:
Failed to read intersphinx_mapping[https://docs.python.org/], ignored: SphinxWarning('The pre-Sphinx 1.0 \'intersphinx_mapping\' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {\'<name>\': (\'[https://docs.python.org/\](https://docs.python.org//)', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping')
```

This PR follows the first example listed [here](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping) to address this warning, allowing the documentation build to succeed.  Sphinx 1.0 was released in 2010, so I think this updated format has been supported for a long time.