### PR TITLE
Update cibuildwheel to 2.15.0

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -29,7 +29,7 @@ jobs:
           arch: AMD64
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -34,7 +34,7 @@ jobs:
         fetch-depth: 0
 
     - name: "Building ${{ matrix.os }} (${{ matrix.arch }}) wheels"
-      uses: pypa/cibuildwheel@v2.9.0
+      uses: pypa/cibuildwheel@v2.15.0
       env:
         # Skips pypy and musllinux for now.
         CIBW_SKIP: "pp* cp36-* *-musllinux*"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Get the version
       shell: bash -l {0}
       id: get_version
-      run: echo ::set-output name=VERSION::$(python setup.py --version)
+      run: echo "name=VERSION::$(python setup.py --version)" >> $GITHUB_OUTPUT
 
     - name: Build documentation
       shell: bash -l {0}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,18 +16,21 @@ jobs:
         fetch-depth: 0
 
     - name: Setup Mamba
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v1
       with:
-        environment-file: false
+        environment-name: TEST
+        create-args: >-
+          python=3
+          numpy>1.13.3
+          sphinx
 
     - name: Build environment
       shell: bash -l {0}
       run: |
-        micromamba create --name TEST python=3 --file requirements.txt --file requirements-dev.txt --channel conda-forge
-        micromamba activate TEST
         python -m pip install -e . --no-deps --force-reinstall
 
     - name: Get the version
+      shell: bash -l {0}
       id: get_version
       run: echo ::set-output name=VERSION::$(python setup.py --version)
 
@@ -35,7 +38,6 @@ jobs:
       shell: bash -l {0}
       run: |
         set -e
-        micromamba activate TEST
         pushd docs
         make html linkcheck O=-W
         popd

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ jobs:
   packages:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/tests_conda.yml
+++ b/.github/workflows/tests_conda.yml
@@ -21,20 +21,23 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Mamba
-      uses: mamba-org/provision-with-micromamba@main
-      with:
-        environment-file: false
-
     - name: Setup micromamba Env
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-name: TEST
+        create-args: >-
+          python=${{ matrix.python-version }}
+          numpy>1.13.3
+          cython>=0.29.20
+          pytest
+          pytest-cov
+
+    - name: Install cftime
       shell: bash -l {0}
       run: |
-        micromamba create --name TEST python=${{ matrix.python-version }} --file requirements.txt --file requirements-dev.txt --channel conda-forge
-        micromamba activate TEST
         pip install -v -e  . --no-deps --force-reinstall
 
     - name: Run Tests
       shell: bash -l {0}
       run: |
-        micromamba activate TEST
         pytest -vv test

--- a/.github/workflows/tests_conda.yml
+++ b/.github/workflows/tests_conda.yml
@@ -19,7 +19,7 @@ jobs:
             platform: x32
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Mamba
       uses: mamba-org/provision-with-micromamba@main

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11-dev"]
+        python-version: ["3.12-dev"]
     steps:
 
     - uses: actions/checkout@v4

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -9,7 +9,7 @@ jobs:
         python-version: ["3.11-dev"]
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=41.2", "cython>=0.29.20", "wheel", "oldest-supported-numpy"]
+requires = ["setuptools>=41.2", "cython>=0.29.20", "wheel", "oldest-supported-numpy; python_version<'3.12.0.rc1'", "numpy>=1.26.0b1; python_version>='3.12.0.rc1'"]
 build-backend = "setuptools.build_meta"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,5 @@ cython>=0.29.20
 pytest
 pytest-cov
 sphinx
-twine
+twine; python_version<'3.12.0.rc1'
 wheel

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,5 @@ cython>=0.29.20
 pytest
 pytest-cov
 sphinx
-twine; python_version<'3.12.0.rc1'
+twine
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-numpy>1.13.3
+numpy>1.13.3; python_version<'3.12.0.rc1'
+numpy>=1.26.0b1; python_version>='3.12.0.rc1'


### PR DESCRIPTION
The motivation for this update is to start building wheels for Python 3.12 by default.