### PR TITLE
MAINT: Build wheels against NumPy 2.0

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -46,6 +46,7 @@ jobs:
           python -c "import cftime; print(f'cftime v{cftime.__version__}')" &&
           python -m pip install check-manifest cython pytest pytest-cov &&
           python -m pytest -vv {package}/test
+        CIBW_BUILD_FRONTEND: 'pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"'
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tests_conda.yml
+++ b/.github/workflows/tests_conda.yml
@@ -17,7 +17,7 @@ jobs:
         platform: [x64, x32]
         experimental: [false]
         exclude:
-          - os: macos-latest  
+          - os: macos-latest
             platform: x32
         include:
           - python-version: "3.12"

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -28,11 +28,11 @@ jobs:
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \
           --no-deps --pre --upgrade \
-          numpy
+          "numpy>=2.0.0.dev0"
 
     - name: Install cftime
       run: |
-        python -m pip install .
+        python -m pip install --no-build-isolation .
 
     - name: Test cftime
       run: |


### PR DESCRIPTION
Opening just for completeness in case 2.0-compatible wheels want to be cut before 2.0 actually comes out. Probably no point in merging if new wheels won't be released before NumPy 2.0.0 is released. So feel free to close!

Related to #325