### PR TITLE
ENH: Build aarch64 linux and simplify matrix

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -40,10 +40,11 @@ jobs:
         platforms: all
       if: runner.os == 'Linux' && matrix.arch == 'aarch64'
 
-
     - name: Build just oldest and newest on PRs, all on tags
       shell: bash
-      # Always omit musl 3.8 b/c NumPy does not provide wheels for it
+      # - Always omit musl 3.8 b/c NumPy does not provide wheels for it
+      # - Omit musllinux on PRs (slow)
+      # - Omit musllinux_aarch64 because it's slow and niche
       run: |
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           CIBW_SKIP="pp* cp36-* cp37-* cp38-musllinux* cp39-* cp310-* cp311-* *musllinux*"

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -2,6 +2,8 @@ name: Wheels
 
 on:
   pull_request:
+    branches:
+      - master
 
   push:
     tags:
@@ -14,19 +16,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "windows-2022", "macos-14"]
-        arch: ["x86_64", "arm64", "AMD64"]
-        exclude:
-        - os: ubuntu-22.04
-          arch: arm64
-        - os: ubuntu-22.04
-          arch: AMD64
-        - os: windows-2022
-          arch: arm64
-        - os: windows-2022
-          arch: x86_64
-        - os: macos-14
-          arch: AMD64
+        include:
+          - os: ubuntu-22.04
+            arch: x86_64
+          - os: ubuntu-22.04
+            arch: aarch64
+          - os: windows-2022
+            arch: AMD64
+          - os: macos-14
+            arch: arm64
+          - os: macos-13
+            arch: x86_64
 
     steps:
     - uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
         CIBW_SKIP: "pp* cp36-* cp37-*"
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-        CIBW_TEST_SKIP: "*_arm64"
+        CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
         CIBW_TEST_REQUIRES: pytest
         CIBW_TEST_COMMAND: >
           python -c "import cftime; print(f'cftime v{cftime.__version__}')" &&

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -48,6 +48,8 @@ jobs:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+        # Emulated testing is slow, so trust that the Python 3.12 test is good enough on aarch64
+        CIBW_TEST_SKIP: "cp38-*_aarch64 cp39-*_aarch64 cp310-*_aarch64 cp311-*_aarch64"
         CIBW_TEST_REQUIRES: pytest
         CIBW_TEST_COMMAND: >
           python -c "import cftime; print(f'cftime v{cftime.__version__}')" &&

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -43,11 +43,12 @@ jobs:
     - name: Build just oldest and newest on PRs, all on tags
       shell: bash
       # - Always omit musl 3.8 b/c NumPy does not provide wheels for it
-      # - Omit musllinux on PRs (slow)
-      # - Omit musllinux_aarch64 because it's slow and niche
+      # - Always omit musllinux_aarch64 because it's slow and niche
+      # - On PPs, omit musllinux for speed
+      # - On PRs, run just oldest and newest Python versions (and omit 3.8 aarch64)
       run: |
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          CIBW_SKIP="pp* cp36-* cp37-* cp38-musllinux* cp39-* cp310-* cp311-* *musllinux*"
+          CIBW_SKIP="pp* cp36-* cp37-* cp38-musllinux* cp39-* cp310-* cp311-* cp38-*-aarch64 *musllinux*"
         else
           CIBW_SKIP="pp* cp36-* cp37-* cp38-musllinux* *musllinux_aarch64"
         fi

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -48,7 +48,7 @@ jobs:
       # - On PRs, run just oldest and newest Python versions (and omit 3.8 aarch64)
       run: |
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          CIBW_SKIP="pp* cp36-* cp37-* cp38-musllinux* cp39-* cp310-* cp311-* cp38-*-aarch64 *musllinux*"
+          CIBW_SKIP="pp* cp36-* cp37-* cp38-musllinux* cp39-* cp310-* cp311-* cp38-*_aarch64 *musllinux*"
         else
           CIBW_SKIP="pp* cp36-* cp37-* cp38-musllinux* *musllinux_aarch64"
         fi

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -45,9 +45,9 @@ jobs:
       shell: bash
       run: |
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          CIBW_SKIP="pp* cp36-* cp37-* cp39-* cp310-* cp311-*"
+          CIBW_SKIP="pp* cp36-* cp37-* cp39-* cp310-* cp311-* *musllinux*"
         else
-          CIBW_SKIP="pp* cp36-* cp37-*"
+          CIBW_SKIP="pp* cp36-* cp37-* *musllinux_aarch64"
         fi
         echo "CIBW_SKIP=$CIBW_SKIP" >> $GITHUB_ENV
         echo "Setting CIBW_SKIP=$CIBW_SKIP"

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -43,11 +43,12 @@ jobs:
 
     - name: Build just oldest and newest on PRs, all on tags
       shell: bash
+      # Always omit musl 3.8 b/c NumPy does not provide wheels for it
       run: |
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          CIBW_SKIP="pp* cp36-* cp37-* cp39-* cp310-* cp311-* *musllinux*"
+          CIBW_SKIP="pp* cp36-* cp37-* cp38-musllinux* cp39-* cp310-* cp311-* *musllinux*"
         else
-          CIBW_SKIP="pp* cp36-* cp37-* *musllinux_aarch64"
+          CIBW_SKIP="pp* cp36-* cp37-* cp38-musllinux* *musllinux_aarch64"
         fi
         echo "CIBW_SKIP=$CIBW_SKIP" >> $GITHUB_ENV
         echo "Setting CIBW_SKIP=$CIBW_SKIP"

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -12,7 +12,7 @@ jobs:
   build_bdist:
     name: "Build ${{ matrix.os }} (${{ matrix.arch }}) wheels"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30  # should be long enough, but let's prevent hangs
+    timeout-minutes: 60  # should be long enough even on tags, but let's prevent hangs
     strategy:
       fail-fast: false
       matrix:
@@ -40,11 +40,23 @@ jobs:
         platforms: all
       if: runner.os == 'Linux' && matrix.arch == 'aarch64'
 
+
+    - name: Build just oldest and newest on PRs, all on tags
+      shell: bash
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          CIBW_SKIP="pp* cp36-* cp37-* cp39-* cp310-* cp311-*"
+        else
+          CIBW_SKIP="pp* cp36-* cp37-*"
+        fi
+        echo "CIBW_SKIP=$CIBW_SKIP" >> $GITHUB_ENV
+        echo "Setting CIBW_SKIP=$CIBW_SKIP"
+
     - name: "Building ${{ matrix.os }} (${{ matrix.arch }}) wheels"
       uses: pypa/cibuildwheel@v2.18.1
       env:
         # Skips pypy py36,37
-        CIBW_SKIP: "pp* cp36-* cp37-*"
+        CIBW_SKIP: ${{ env.CIBW_SKIP }}
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -49,6 +49,7 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
         # Emulated testing is slow, so trust that the Python 3.12 test is good enough on aarch64
+        # (takes about 5 minutes per wheel to build, and 5 minutes to test)
         CIBW_TEST_SKIP: "cp38-*_aarch64 cp39-*_aarch64 cp310-*_aarch64 cp311-*_aarch64"
         CIBW_TEST_REQUIRES: pytest
         CIBW_TEST_COMMAND: >

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 since version 1.6.3 release
 ===========================
+ * build aarch64 linux wheels (issue #333).
  * build musllinux wheels (issue #307).
  * return empty array if one provided to date2num (issue #315).
  * numpy 2.0 compatibility (issue #325).


### PR DESCRIPTION
This has some opinionated optional changes, let me know if they're worth keeping:

1. Instead of making a 3x3 build matrix that results in 9 entries then exclude 5 of them... just `include:` the desired ones explicitly. It seems more readable in the end to me at least!
2. Build and test wheels on PRs against `master`. Assuming it's fast enough, might as well if it's quick (but can be reverted if it's not!) since it tests a bunch of archs/oses.
3. Don't exclude testing on arm64, it's on native hardware with `macos-14` so should be fast enough hopefully?
4. Build the x86_64 macOS wheels on macos-13 which is natively Intel / x86_64 rather than cross-compiling on macos-14 (which is arm64)

And it also includes the change that I actually set out to implement, namely adding Linux `aarch64` wheels.

Closes #333