### PR TITLE
MAINT: Run wheel build on PRs, too

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -2,7 +2,8 @@ name: Wheels
 
 on:
   pull_request:
-
+    branches:
+      - master
   push:
     tags:
       - "v*"


### PR DESCRIPTION
Tiny PR with part of #334 (namely, running wheel builds on PRs) to get merged so that iterating in #334 is workable without the need for approving every commit.