### PR TITLE
WHL: build limited-api compliant wheels

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -46,16 +46,21 @@ jobs:
       if:  ${{ github.event_name }} == pull_request
       shell: bash
       # - On PPs, omit musllinux for speed
-      # - On PRs, run just oldest and newest Python versions
+      # - On PRs, run just oldest and newest Python versions (3.11 is the oldest abi3 target)
       run: |
-        CIBW_SKIP="cp310-win_arm64 cp311-* cp312-* cp313-* *musllinux*"
+        CIBW_SKIP="cp310-win_arm64 *musllinux*"
         echo "CIBW_SKIP=$CIBW_SKIP" >> $GITHUB_ENV
         echo "Setting CIBW_SKIP=$CIBW_SKIP"
+
+        CIBW_TEST_SKIP="cp312-* cp313-*"
+        echo "CIBW_TEST_SKIP=$CIBW_TEST_SKIP" >> $GITHUB_ENV
+        echo "Setting CIBW_TEST_SKIP=$CIBW_TEST_SKIP"
 
     - name: "Building ${{ matrix.os }} (${{ matrix.arch }}) wheels"
       uses: pypa/cibuildwheel@v3.3.1
       env:
         CIBW_SKIP: ${{ env.CIBW_SKIP }}
+        CIBW_TEST_SKIP: ${{ env.CIBW_TEST_SKIP }}
         CIBW_ARCHS: ${{ matrix.arch }}
 
     - uses: actions/upload-artifact@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,3 +127,4 @@ test-command = [
 ]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
+environment = { CFTIME_LIMITED_API = "1" }

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ ABI3_TARGET_VERSION = "".join(str(_) for _ in sys.version_info[:2])
 ABI3_TARGET_HEX = hex(sys.hexversion & 0xFFFF00F0)
 
 if USE_PY_LIMITED_API:
+    DEFINE_MACROS  += [(("Py_LIMITED_API", ABI3_TARGET_HEX))]
+    
+if USE_PY_LIMITED_API:
     SETUP_OPTIONS = {"bdist_wheel": {"py_limited_api": f"cp{ABI3_TARGET_VERSION}"}}
 else:
     SETUP_OPTIONS = {}
@@ -76,8 +79,7 @@ if ((FLAG_COVERAGE in sys.argv or os.environ.get('CYTHON_COVERAGE', None))
     }
     DEFINE_MACROS += [('CYTHON_TRACE', '1'),
                      ('CYTHON_TRACE_NOGIL', '1')]
-    if USE_PY_LIMITED_API:
-        DEFINE_MACROS.append(("Py_LIMITED_API", ABI3_TARGET_HEX))
+
     if FLAG_COVERAGE in sys.argv:
         sys.argv.remove(FLAG_COVERAGE)
     print('enable: "linetrace" Cython compiler directive')

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import sysconfig
 import numpy
 
 from Cython.Build import cythonize
@@ -29,6 +30,21 @@ NAME = 'cftime'
 CFTIME_DIR = os.path.join(SRCDIR, NAME)
 CYTHON_FNAME = os.path.join(CFTIME_DIR, '_{}.pyx'.format(NAME))
 
+USE_PY_LIMITED_API = (
+    # require opt-in (builds are specialized by default)
+    os.getenv('CFTIME_LIMITED_API', '0') == '1'
+    # Cython + numpy + limited API de facto requires Python >=3.11
+    and sys.version_info >= (3, 11)
+    # as of Python 3.14t, free-threaded builds don't support the limited API
+    and not sysconfig.get_config_var("Py_GIL_DISABLED")
+)
+ABI3_TARGET_VERSION = "".join(str(_) for _ in sys.version_info[:2])
+ABI3_TARGET_HEX = hex(sys.hexversion & 0xFFFF00F0)
+
+if USE_PY_LIMITED_API:
+    SETUP_OPTIONS = {"bdist_wheel": {"py_limited_api": f"cp{ABI3_TARGET_VERSION}"}}
+else:
+    SETUP_OPTIONS = {}
 
 class CleanCython(Command):
     description = 'Purge artifacts built by Cython'
@@ -60,6 +76,8 @@ if ((FLAG_COVERAGE in sys.argv or os.environ.get('CYTHON_COVERAGE', None))
     }
     DEFINE_MACROS += [('CYTHON_TRACE', '1'),
                      ('CYTHON_TRACE_NOGIL', '1')]
+    if USE_PY_LIMITED_API:
+        DEFINE_MACROS.append(("Py_LIMITED_API", ABI3_TARGET_HEX))
     if FLAG_COVERAGE in sys.argv:
         sys.argv.remove(FLAG_COVERAGE)
     print('enable: "linetrace" Cython compiler directive')
@@ -71,7 +89,8 @@ else:
     extension = Extension('{}._{}'.format(NAME, NAME),
                           sources=[os.path.relpath(CYTHON_FNAME, BASEDIR)],
                           define_macros=DEFINE_MACROS,
-                          include_dirs=[numpy.get_include(),])
+                          include_dirs=[numpy.get_include()],
+                          py_limited_api=USE_PY_LIMITED_API)
 
     ext_modules = cythonize(
         extension,
@@ -82,4 +101,5 @@ else:
 setup(
     cmdclass={'clean_cython': CleanCython},
     ext_modules=ext_modules,
+    options=SETUP_OPTIONS,
 )


### PR DESCRIPTION
Based off #371, similar to Unidata/netcdf4-python#1427
I've included a commit to drop support for 3.8 and 3.9 (soon to be EOL), but it can easily be split out of this PR if desired.