### PR TITLE
MNT: upgrade macos-intel image

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -25,7 +25,7 @@ jobs:
             arch: AMD64
           - os: macos-14
             arch: arm64
-          - os: macos-13
+          - os: macos-15-intel
             arch: x86_64
 
     steps:


### PR DESCRIPTION
Just noticed `macos-13` (deprecated, undergoing brownouts) is still in use here, let's upgrade the image for 2 more years of easy support.